### PR TITLE
🔥 Remove the rich text option that fails in the md preview

### DIFF
--- a/pages/nft-book-store/new.vue
+++ b/pages/nft-book-store/new.vue
@@ -164,10 +164,9 @@ const totalStock = computed(() => prices.value.reduce((acc, p) => acc + Number(p
 const toolbarOptions = ref<string[]>([
   'bold',
   'italic',
-  '-',
   'strikeThrough',
   'title',
-  'quote',
+  '-',
   'unorderedList',
   'orderedList',
   '-',


### PR DESCRIPTION
<img width="910" alt="截圖 2023-08-02 上午8 29 46" src="https://github.com/likecoin/nft-book-press/assets/75730405/981dcb28-e546-4369-b56c-287bf94a8385">
<img width="651" alt="截圖 2023-08-02 上午8 27 15" src="https://github.com/likecoin/nft-book-press/assets/75730405/13107787-8d64-4c1d-bec9-e3a0ee268b18">
