### PR TITLE
[TAS-1447] ✨ Add likerID affiliation info in stripe connect page

### DIFF
--- a/constant/index.ts
+++ b/constant/index.ts
@@ -21,6 +21,7 @@ export const LIKER_NFT_TARGET_ADDRESS = IS_TESTNET
   ? 'like1yney2cqn5qdrlc50yr5l53898ufdhxafqz9gxp'
   : 'like17m4vwrnhjmd20uu7tst7nv0kap6ee7js69jfrs'
 
+export const LIKE_CO_HOST = `https://${IS_TESTNET ? 'rinkeby.' : ''}like.co`
 export const LIKE_CO_API = `https://api.${IS_TESTNET ? 'rinkeby.' : ''}like.co`
 export const APP_LIKE_CO_URL = `https://app.${IS_TESTNET ? 'rinkeby.' : ''}like.co`
 export const LIKER_LAND_URL = `https://${LIKER_LAND_HOST}`


### PR DESCRIPTION
Require: https://github.com/likecoin/likecoin-api-public/pull/636
Expected userflow:
- Register likerid
- Register stripe connect
- Sell book using from=@likerid qs
- Profit

TODO:
- allow user to register for likerid in this UI? Requires modification of like.co API