### PR TITLE
🐛 Fix shippingRates is not updated in edit collection

### DIFF
--- a/pages/nft-book-store/collection/status/[collectionId]/edit.vue
+++ b/pages/nft-book-store/collection/status/[collectionId]/edit.vue
@@ -88,6 +88,7 @@
           v-model="hasShipping"
           :read-only="true"
           :shipping-info="shippingRates"
+          @on-update-shipping-rates="value => shippingRates = value"
         />
 
         <UFormGroup


### PR DESCRIPTION
Need to review if we need all `ShippingRatesRateTable` to have `@on-update-shipping-rates` set, or just don't allow read-only `ShippingRatesRateTable` to mutate