### PR TITLE
🎨 Improve shipping rate update flow in edit collection

### DIFF
--- a/components/ShippingRates/InfoModal.vue
+++ b/components/ShippingRates/InfoModal.vue
@@ -129,7 +129,7 @@ const props = defineProps({
     default: () => []
   }
 })
-const emit = defineEmits(['update:modelValue', 'on-update-shipping-rates'])
+const emit = defineEmits(['update:modelValue', 'update-shipping-rates'])
 const isEditMode = computed(() => !isReadOnlyMode.value)
 const isViewMode = computed(() => isReadOnlyMode.value)
 const modalTitle = computed(() =>
@@ -182,7 +182,7 @@ function deleteShippingRate (index: number) {
 }
 
 function handleOnSave () {
-  emit('on-update-shipping-rates', shippingRates.value.map((option:any) => ({ name: { en: option.nameEn, zh: option.nameZh }, priceInDecimal: Math.round(Number(option.price) * 100) })))
+  emit('update-shipping-rates', shippingRates.value.map((option:any) => ({ name: { en: option.nameEn, zh: option.nameZh }, priceInDecimal: Math.round(Number(option.price) * 100) })))
   closeModal()
 }
 </script>

--- a/components/ShippingRates/RateTable.vue
+++ b/components/ShippingRates/RateTable.vue
@@ -78,7 +78,7 @@ const props = defineProps({
     type: Boolean,
     default: false
   },
-  isClassView: {
+  isShowPhysicalGoodsCheckbox: {
     type: Boolean,
     default: false
   },
@@ -89,7 +89,7 @@ const props = defineProps({
   modelValue: {
     type: Boolean
   },
-  isNewListingPage: {
+  isShowSettingModalButton: {
     type: Boolean,
     default: false
   }
@@ -98,6 +98,7 @@ const emit = defineEmits(['update:modelValue', 'update-shipping-rates'])
 const isShippingModalOpened = ref<Boolean>(false)
 
 const hasShipping = ref(props.modelValue)
+const isModalReadOnly = ref(props.isShowPhysicalGoodsCheckbox)
 
 watch(() => props.modelValue, (newValue) => {
   hasShipping.value = newValue
@@ -105,10 +106,9 @@ watch(() => props.modelValue, (newValue) => {
 watch(hasShipping, (hasShipping) => {
   emit('update:modelValue', hasShipping)
 })
-const isModalReadOnly = computed(() => (!props.isClassView))
-const isEditMode = computed(() => (props.isClassView))
-const isViewMode = computed(() => !(props.isClassView))
-const shouldHideViewButtonOnViewMode = computed(() => Boolean(isViewMode.value && props.isNewListingPage))
+const isEditMode = computed(() => !(props.isShowPhysicalGoodsCheckbox))
+const isViewMode = computed(() => (props.isShowPhysicalGoodsCheckbox))
+const shouldHideViewButtonOnViewMode = computed(() => Boolean(isViewMode.value && props.isShowSettingModalButton))
 const buttonConfig = computed(() => {
   if (isEditMode.value) {
     if (props.shippingInfo.length) {

--- a/components/ShippingRates/RateTable.vue
+++ b/components/ShippingRates/RateTable.vue
@@ -65,8 +65,8 @@
       v-model="isShippingModalOpened"
       :read-only="isModalReadOnly"
       :shipping-info="shippingInfo"
-      @on-update-shipping-rates="
-        (value) => emit('on-update-shipping-rates', value)"
+      @update-shipping-rates="
+        (value) => emit('update-shipping-rates', value)"
     />
   </UCard>
 </template>
@@ -94,7 +94,7 @@ const props = defineProps({
     default: false
   }
 })
-const emit = defineEmits(['update:modelValue', 'on-update-shipping-rates'])
+const emit = defineEmits(['update:modelValue', 'update-shipping-rates'])
 const isShippingModalOpened = ref<Boolean>(false)
 
 const hasShipping = ref(props.modelValue)

--- a/components/ShippingRates/RateTable.vue
+++ b/components/ShippingRates/RateTable.vue
@@ -78,7 +78,7 @@ const props = defineProps({
     type: Boolean,
     default: false
   },
-  readOnly: {
+  isClassView: {
     type: Boolean,
     default: false
   },
@@ -98,15 +98,15 @@ const emit = defineEmits(['update:modelValue', 'on-update-shipping-rates'])
 const isShippingModalOpened = ref<Boolean>(false)
 
 const hasShipping = ref(props.modelValue)
-const isModalReadOnly = ref(props.readOnly)
+const isModalReadOnly = ref(!props.isClassView)
 watch(() => props.modelValue, (newValue) => {
   hasShipping.value = newValue
 })
 watch(hasShipping, (hasShipping) => {
   emit('update:modelValue', hasShipping)
 })
-const isEditMode = computed(() => !(props.readOnly))
-const isViewMode = computed(() => (props.readOnly))
+const isEditMode = computed(() => (props.isClassView))
+const isViewMode = computed(() => !(props.isClassView))
 const shouldHideViewButtonOnViewMode = computed(() => Boolean(isViewMode.value && props.isNewListingPage))
 const buttonConfig = computed(() => {
   if (isEditMode.value) {

--- a/components/ShippingRates/RateTable.vue
+++ b/components/ShippingRates/RateTable.vue
@@ -98,13 +98,14 @@ const emit = defineEmits(['update:modelValue', 'update-shipping-rates'])
 const isShippingModalOpened = ref<Boolean>(false)
 
 const hasShipping = ref(props.modelValue)
-const isModalReadOnly = ref(!props.isClassView)
+
 watch(() => props.modelValue, (newValue) => {
   hasShipping.value = newValue
 })
 watch(hasShipping, (hasShipping) => {
   emit('update:modelValue', hasShipping)
 })
+const isModalReadOnly = computed(() => (!props.isClassView))
 const isEditMode = computed(() => (props.isClassView))
 const isViewMode = computed(() => !(props.isClassView))
 const shouldHideViewButtonOnViewMode = computed(() => Boolean(isViewMode.value && props.isNewListingPage))

--- a/pages/nft-book-store/collection/new.vue
+++ b/pages/nft-book-store/collection/new.vue
@@ -112,7 +112,7 @@
             :is-class-view="true"
             :shipping-info="shippingRates"
             :is-new-listing-page="true"
-            @on-update-shipping-rates="updateShippingRate"
+            @update-shipping-rates="updateShippingRate"
           >
             <template #header>
               <span class="text-[14px] text-gray-500">

--- a/pages/nft-book-store/collection/new.vue
+++ b/pages/nft-book-store/collection/new.vue
@@ -109,7 +109,7 @@
           </UFormGroup>
 
           <ShippingRatesRateTable
-            :read-only="false"
+            :is-class-view="true"
             :shipping-info="shippingRates"
             :is-new-listing-page="true"
             @on-update-shipping-rates="updateShippingRate"

--- a/pages/nft-book-store/collection/new.vue
+++ b/pages/nft-book-store/collection/new.vue
@@ -109,9 +109,9 @@
           </UFormGroup>
 
           <ShippingRatesRateTable
-            :is-class-view="true"
+            :is-show-physical-goods-checkbox="false"
             :shipping-info="shippingRates"
-            :is-new-listing-page="true"
+            :is-show-setting-modal-button="true"
             @update-shipping-rates="updateShippingRate"
           >
             <template #header>

--- a/pages/nft-book-store/collection/status/[collectionId].vue
+++ b/pages/nft-book-store/collection/status/[collectionId].vue
@@ -169,7 +169,7 @@
       </UCard>
 
       <ShippingRatesRateTable
-        :read-only="false"
+        :is-class-view="true"
         :is-loading="isUpdatingShippingRates"
         :shipping-info="collectionListingInfo.shippingRates"
         @on-update-shipping-rates="updateShippingRates"

--- a/pages/nft-book-store/collection/status/[collectionId].vue
+++ b/pages/nft-book-store/collection/status/[collectionId].vue
@@ -169,7 +169,7 @@
       </UCard>
 
       <ShippingRatesRateTable
-        :is-class-view="true"
+        :is-show-physical-goods-checkbox="false"
         :is-loading="isUpdatingShippingRates"
         :shipping-info="collectionListingInfo.shippingRates"
         @update-shipping-rates="updateShippingRates"

--- a/pages/nft-book-store/collection/status/[collectionId].vue
+++ b/pages/nft-book-store/collection/status/[collectionId].vue
@@ -172,7 +172,7 @@
         :is-class-view="true"
         :is-loading="isUpdatingShippingRates"
         :shipping-info="collectionListingInfo.shippingRates"
-        @on-update-shipping-rates="updateShippingRates"
+        @update-shipping-rates="updateShippingRates"
       />
 
       <UCard

--- a/pages/nft-book-store/collection/status/[collectionId]/edit.vue
+++ b/pages/nft-book-store/collection/status/[collectionId]/edit.vue
@@ -86,7 +86,7 @@
 
         <ShippingRatesRateTable
           v-model="hasShipping"
-          :read-only="true"
+          :is-class-view="false"
           :shipping-info="shippingRates"
           :is-loading="isUpdatingShippingRates"
           @on-update-shipping-rates="updateShippingRates"

--- a/pages/nft-book-store/collection/status/[collectionId]/edit.vue
+++ b/pages/nft-book-store/collection/status/[collectionId]/edit.vue
@@ -88,7 +88,8 @@
           v-model="hasShipping"
           :read-only="true"
           :shipping-info="shippingRates"
-          @on-update-shipping-rates="value => shippingRates = value"
+          :is-loading="isUpdatingShippingRates"
+          @on-update-shipping-rates="updateShippingRates"
         />
 
         <UFormGroup
@@ -152,6 +153,7 @@ const hasShipping = ref(false)
 const isAllowCustomPrice = ref(false)
 const isPhysicalOnly = ref(false)
 const shippingRates = ref<any[]>([])
+const isUpdatingShippingRates = ref(false)
 
 const toolbarOptions = ref<string[]>([
   'bold',
@@ -239,6 +241,23 @@ function handleClickBack () {
   })
 }
 
+async function updateShippingRates (value: any) {
+  isUpdatingShippingRates.value = true
+  try {
+    await collectionStore.updateNFTBookCollectionById(collectionId.value as string, {
+      shippingRates: value
+    })
+
+    const updatedCollectionData = (await collectionStore.fetchCollectionById(collectionId.value as string)).value
+    shippingRates.value = updatedCollectionData?.typePayload?.shippingRates
+  } catch (err) {
+    const errorData = (err as any).data || err
+    console.error(errorData)
+  } finally {
+    isUpdatingShippingRates.value = false
+  }
+}
+
 async function handleSubmit () {
   try {
     const editedPrice = {
@@ -257,8 +276,7 @@ async function handleSubmit () {
       stock: Number(stock.value),
       hasShipping: hasShipping.value || false,
       isPhysicalOnly: isPhysicalOnly.value || false,
-      isAllowCustomPrice: isAllowCustomPrice.value || false,
-      shippingRates: shippingRates.value || []
+      isAllowCustomPrice: isAllowCustomPrice.value || false
     }
 
     if (!editedPrice || editedPrice.price === undefined) {

--- a/pages/nft-book-store/collection/status/[collectionId]/edit.vue
+++ b/pages/nft-book-store/collection/status/[collectionId]/edit.vue
@@ -86,7 +86,7 @@
 
         <ShippingRatesRateTable
           v-model="hasShipping"
-          :is-class-view="false"
+          :is-show-physical-goods-checkbox="true"
           :shipping-info="shippingRates"
           :is-loading="isUpdatingShippingRates"
           @update-shipping-rates="updateShippingRates"

--- a/pages/nft-book-store/collection/status/[collectionId]/edit.vue
+++ b/pages/nft-book-store/collection/status/[collectionId]/edit.vue
@@ -89,7 +89,7 @@
           :is-class-view="false"
           :shipping-info="shippingRates"
           :is-loading="isUpdatingShippingRates"
-          @on-update-shipping-rates="updateShippingRates"
+          @update-shipping-rates="updateShippingRates"
         />
 
         <UFormGroup

--- a/pages/nft-book-store/new.vue
+++ b/pages/nft-book-store/new.vue
@@ -228,7 +228,7 @@
 
             <ShippingRatesRateTable
               v-model="p.hasShipping"
-              :read-only="true"
+              :is-class-view="false"
               :is-new-listing-page="true"
               :shipping-info="shippingRates"
             />
@@ -437,7 +437,7 @@
 
             <!-- Shipping Rates -->
             <ShippingRatesRateTable
-              :read-only="false"
+              :is-class-view="true"
               :is-new-listing-page="true"
               :shipping-info="shippingRates"
               @on-update-shipping-rates="updateShippingRate"

--- a/pages/nft-book-store/new.vue
+++ b/pages/nft-book-store/new.vue
@@ -440,7 +440,7 @@
               :is-class-view="true"
               :is-new-listing-page="true"
               :shipping-info="shippingRates"
-              @on-update-shipping-rates="updateShippingRate"
+              @update-shipping-rates="updateShippingRate"
             />
 
             <!-- Share sales data -->

--- a/pages/nft-book-store/new.vue
+++ b/pages/nft-book-store/new.vue
@@ -228,8 +228,8 @@
 
             <ShippingRatesRateTable
               v-model="p.hasShipping"
-              :is-class-view="false"
-              :is-new-listing-page="true"
+              :is-show-physical-goods-checkbox="true"
+              :is-show-setting-modal-button="true"
               :shipping-info="shippingRates"
             />
             <div class="flex justify-center items-center">
@@ -437,8 +437,8 @@
 
             <!-- Shipping Rates -->
             <ShippingRatesRateTable
-              :is-class-view="true"
-              :is-new-listing-page="true"
+              :is-show-physical-goods-checkbox="false"
+              :is-show-setting-modal-button="true"
               :shipping-info="shippingRates"
               @update-shipping-rates="updateShippingRate"
             />

--- a/pages/nft-book-store/status/[classId].vue
+++ b/pages/nft-book-store/status/[classId].vue
@@ -261,7 +261,7 @@
         :is-class-view="true"
         :is-loading="isUpdatingShippingRates"
         :shipping-info="classListingInfo.shippingRates"
-        @on-update-shipping-rates="updateShippingRates"
+        @update-shipping-rates="updateShippingRates"
       />
 
       <UCard

--- a/pages/nft-book-store/status/[classId].vue
+++ b/pages/nft-book-store/status/[classId].vue
@@ -258,7 +258,7 @@
       </UCard>
 
       <ShippingRatesRateTable
-        :is-class-view="true"
+        :is-show-physical-goods-checkbox="false"
         :is-loading="isUpdatingShippingRates"
         :shipping-info="classListingInfo.shippingRates"
         @update-shipping-rates="updateShippingRates"

--- a/pages/nft-book-store/status/[classId].vue
+++ b/pages/nft-book-store/status/[classId].vue
@@ -258,7 +258,7 @@
       </UCard>
 
       <ShippingRatesRateTable
-        :read-only="false"
+        :is-class-view="true"
         :is-loading="isUpdatingShippingRates"
         :shipping-info="classListingInfo.shippingRates"
         @on-update-shipping-rates="updateShippingRates"

--- a/pages/nft-book-store/status/[classId]/edit/[editionIndex].vue
+++ b/pages/nft-book-store/status/[classId]/edit/[editionIndex].vue
@@ -92,7 +92,7 @@
 
         <ShippingRatesRateTable
           v-model="hasShipping"
-          :read-only="true"
+          :is-class-view="false"
           :shipping-info="shippingRates"
           :is-loading="isUpdatingShippingRates"
           @on-update-shipping-rates="updateShippingRates"

--- a/pages/nft-book-store/status/[classId]/edit/[editionIndex].vue
+++ b/pages/nft-book-store/status/[classId]/edit/[editionIndex].vue
@@ -92,7 +92,7 @@
 
         <ShippingRatesRateTable
           v-model="hasShipping"
-          :is-class-view="false"
+          :is-show-physical-goods-checkbox="true"
           :shipping-info="shippingRates"
           :is-loading="isUpdatingShippingRates"
           @update-shipping-rates="updateShippingRates"

--- a/pages/nft-book-store/status/[classId]/edit/[editionIndex].vue
+++ b/pages/nft-book-store/status/[classId]/edit/[editionIndex].vue
@@ -95,7 +95,7 @@
           :is-class-view="false"
           :shipping-info="shippingRates"
           :is-loading="isUpdatingShippingRates"
-          @on-update-shipping-rates="updateShippingRates"
+          @update-shipping-rates="updateShippingRates"
         />
 
         <UFormGroup

--- a/pages/nft-book-store/status/[classId]/edit/new.vue
+++ b/pages/nft-book-store/status/[classId]/edit/new.vue
@@ -91,7 +91,7 @@
 
         <ShippingRatesRateTable
           v-model="hasShipping"
-          :is-class-view="false"
+          :is-show-physical-goods-checkbox="true"
           :shipping-info="shippingRates"
           :is-loading="isUpdatingShippingRates"
           @update-shipping-rates="updateShippingRates"

--- a/pages/nft-book-store/status/[classId]/edit/new.vue
+++ b/pages/nft-book-store/status/[classId]/edit/new.vue
@@ -91,7 +91,7 @@
 
         <ShippingRatesRateTable
           v-model="hasShipping"
-          :read-only="true"
+          :is-class-view="false"
           :shipping-info="shippingRates"
           :is-loading="isUpdatingShippingRates"
           @on-update-shipping-rates="updateShippingRates"

--- a/pages/nft-book-store/status/[classId]/edit/new.vue
+++ b/pages/nft-book-store/status/[classId]/edit/new.vue
@@ -94,7 +94,7 @@
           :is-class-view="false"
           :shipping-info="shippingRates"
           :is-loading="isUpdatingShippingRates"
-          @on-update-shipping-rates="updateShippingRates"
+          @update-shipping-rates="updateShippingRates"
         />
 
         <UFormGroup


### PR DESCRIPTION
- Update collection class data when setting shipping rate in read-only.
- Improve props name 

`isClassView`
![截圖 2024-03-21 上午9 47 40](https://github.com/likecoin/nft-book-press/assets/75730405/0801fbbe-8a69-48d3-80b4-172b358eb94f)

`!isClassView`
![截圖 2024-03-21 上午9 47 51](https://github.com/likecoin/nft-book-press/assets/75730405/2f342a04-82fc-4c79-979b-b705962750c6)
