### PR TITLE
✨ Add book user store and notification email setting

### DIFF
--- a/components/SiteMenu.vue
+++ b/components/SiteMenu.vue
@@ -59,7 +59,7 @@ const items = [
         exact: true
       },
       {
-        label: 'Manage Stripe Account',
+        label: 'Manage User Setting',
         icon: 'i-heroicons-user-group',
         to: { name: 'nft-book-store-user' },
         exact: true

--- a/stores/user.ts
+++ b/stores/user.ts
@@ -1,0 +1,55 @@
+import { defineStore, storeToRefs } from 'pinia'
+import { useBookStoreApiStore } from './book-store-api'
+import { LIKE_CO_API } from '~/constant'
+
+export const useUserStore = defineStore('user', () => {
+  const bookStoreApiStore = useBookStoreApiStore()
+  const { token } = storeToRefs(bookStoreApiStore)
+
+  const bookUser = ref(null as any)
+
+  async function fetchBookUserProfile () {
+    const { error, data } = await useFetch(
+      `${LIKE_CO_API}/likernft/book/user/profile`,
+      {
+        headers: {
+          authorization: `Bearer ${token.value}`
+        }
+      }
+    )
+    if (error.value) {
+      throw error.value
+    }
+    bookUser.value = data.value
+    return bookUser.value
+  }
+
+  function lazyFetchBookUserProfile () {
+    if (bookUser.value) {
+      return bookUser.value
+    }
+    return fetchBookUserProfile()
+  }
+
+  async function updateBookUserProfile (payload: any) {
+    const { error } = await useFetch(`${LIKE_CO_API}/likernft/book/user/profile`, {
+      method: 'POST',
+      body: payload,
+      headers: {
+        authorization: `Bearer ${token.value}`
+      }
+    })
+    if (error.value) {
+      throw error.value
+    }
+    bookUser.value = { ...bookUser.value, ...payload }
+    return bookUser.value
+  }
+
+  return {
+    bookUser,
+    fetchBookUserProfile,
+    lazyFetchBookUserProfile,
+    updateBookUserProfile
+  }
+})


### PR DESCRIPTION
Base on https://github.com/likecoin/nft-book-press/pull/131
Requires https://github.com/likecoin/likecoin-api-public/pull/652
<img width="750" alt="image" src="https://github.com/likecoin/nft-book-press/assets/6198816/53155b29-e370-4bd0-9576-c41ace2b3107">


- Add notification email setting for affiliation page
- Add book store and fetch book user action

TODO: 
- fetch book user on any page of book press