### PR TITLE
[TAS-1815] 🐛 Fix issue with duplicate logins

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@cosmjs/proto-signing": "^0.30.1",
     "@cosmjs/stargate": "^0.30.1",
     "@likecoin/iscn-js": "^0.6.10",
-    "@likecoin/wallet-connector": "^0.26.0",
+    "@likecoin/wallet-connector": "^0.26.2",
     "@nuxt/ui": "^2.10.0",
     "@pinia/nuxt": "^0.4.8",
     "bignumber.js": "^9.1.0",

--- a/pages/nft-book-store.vue
+++ b/pages/nft-book-store.vue
@@ -50,13 +50,12 @@ watch(isLoading, (newIsLoading) => {
   if (newIsLoading) { error.value = '' }
 })
 
-onMounted(async () => {
+onMounted(() => {
   try {
     const payload = window.localStorage.getItem('likecoin_nft_book_press_token')
     if (payload) {
       const { wallet: storedWallet, token } = JSON.parse(payload)
       restoreSession(storedWallet, token)
-      await connect()
     }
   } catch {}
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1801,7 +1801,7 @@
     fast-json-stable-stringify "^2.0.0"
     lodash "^4.17.15"
 
-"@likecoin/wallet-connector@^0.26.0":
+"@likecoin/wallet-connector@^0.26.2":
   version "0.26.2"
   resolved "https://registry.yarnpkg.com/@likecoin/wallet-connector/-/wallet-connector-0.26.2.tgz#b9e7ec87652a76ce8a1d97ed16d43ef97d86d0be"
   integrity sha512-+1V/3v6fq0C9oHEF8i2ayvYxMyOVQMDKEt+eVm2qthIvd428h+ks6YkOKmpeBfNlR+pNz98LRWBdQCnPrGm4cQ==


### PR DESCRIPTION
We've already triggered `connect()` in [WalletHeader](https://github.com/likecoin/nft-book-press/blob/master/components/WalletHeader.vue#L48), which has led to a race condition. 
This can easily cause `initIfNecessary()` to fail, resulting to open [`openConnectionMethodSelectionDialog()`](https://github.com/likecoin/nft-book-press/blob/master/stores/wallet.ts#L100).
