### PR TITLE
🚑️ Fix duplicated listing entry

### DIFF
--- a/pages/nft-book-store/index.vue
+++ b/pages/nft-book-store/index.vue
@@ -314,7 +314,7 @@ async function fetchBookList (params: { key?: number, limit?: number } = {}) {
   }
 
   const { nextKey, list = [] } = (data.value as any) || {}
-  if (params) {
+  if (params.key) {
     bookList.value.push(...list)
   } else {
     bookList.value = list


### PR DESCRIPTION
It was defined that `params: { key?: number, limit?: number } = {}`, so `params` is true-ful by default