### PR TITLE
🚸 Improvements to the NFT Minting Flow

### DIFF
--- a/components/EditISCNMetadataModal.vue
+++ b/components/EditISCNMetadataModal.vue
@@ -248,7 +248,7 @@ async function handleSave () {
     }
     toast.add({
       title: 'ISCN updated successfully',
-      color: 'green'
+      color: 'blue'
     })
     emit('save')
     handleClickBack()

--- a/components/RegisterISCN.vue
+++ b/components/RegisterISCN.vue
@@ -113,7 +113,7 @@ const initializeFromSessionStorage = () => {
     description: stripHtmlTags(data.epubMetadata?.description || ''),
     isbn: '',
     publisher: '',
-    publicationDate: '',
+    publicationDate: new Date().toISOString().split('T')[0],
     author: {
       name: data.epubMetadata?.author || '',
       description: ''

--- a/constant/index.ts
+++ b/constant/index.ts
@@ -44,10 +44,7 @@ export const languageOptions = [
 ]
 
 export const typeOptions = [
-  { label: 'Book', value: 'Book' },
-  { label: 'Photo', value: 'Photo' },
-  { label: 'Image', value: 'Image' },
-  { label: 'CreativeWork', value: 'CreativeWork' }
+  { label: 'Book', value: 'Book' }
 ]
 
 export const licenseOptions = [

--- a/pages/mint-nft/index.vue
+++ b/pages/mint-nft/index.vue
@@ -3,452 +3,454 @@
     <PageHeader title="Mint Liker Land NFT Book" />
 
     <PageBody class="flex flex-col items-stretch grow space-y-4">
-      <UAlert
-        v-if="error"
-        icon="i-heroicons-exclamation-triangle"
-        color="red"
-        variant="soft"
-        :title="`${error}`"
-        :close-button="{ icon: 'i-heroicons-x-mark-20-solid', color: 'red', variant: 'link', padded: false }"
-        @close="error = ''"
-      />
-      <UAlert
-        v-else
-        icon="i-heroicons-exclamation-circle"
-        color="green"
-        variant="soft"
-        title="First time? 新用戶請看這裏"
-        description="Read our guide to learn how to publish NFT Book."
-        :actions="[{
-          label: 'Read our guide',
-          color: 'green',
-          variant: 'outline',
-          click: onClickHelpEn,
-        }, {
-          label: '打開教學',
-          color: 'green',
-          variant: 'outline',
-          click: onClickHelpZh,
-        },{
-          label: 'Listing Disclaimer',
-          color: 'green',
-          variant: 'outline',
-          click: onClickDisclaimerEn,
-        },{
-          label: '上架須知和收費',
-          color: 'green',
-          variant: 'outline',
-          click: onClickDisclaimerZh,
-        }]"
-      />
-      <UDivider :label="`Steps ${step} / 4`" />
-
-      <UCard
-        v-if="step === 1"
-        :ui="{ body: { base: 'space-y-4' } }"
-      >
-        <template #header>
-          <h2 class="font-bold font-mono">
-            1. Select or Create ISCN
-          </h2>
-        </template>
+      <AuthRequiredView>
+        <UAlert
+          v-if="error"
+          icon="i-heroicons-exclamation-triangle"
+          color="red"
+          variant="soft"
+          :title="`${error}`"
+          :close-button="{ icon: 'i-heroicons-x-mark-20-solid', color: 'red', variant: 'link', padded: false }"
+          @close="error = ''"
+        />
+        <UAlert
+          v-else
+          icon="i-heroicons-exclamation-circle"
+          color="green"
+          variant="soft"
+          title="First time? 新用戶請看這裏"
+          description="Read our guide to learn how to publish NFT Book."
+          :actions="[{
+            label: 'Read our guide',
+            color: 'green',
+            variant: 'outline',
+            click: onClickHelpEn,
+          }, {
+            label: '打開教學',
+            color: 'green',
+            variant: 'outline',
+            click: onClickHelpZh,
+          },{
+            label: 'Listing Disclaimer',
+            color: 'green',
+            variant: 'outline',
+            click: onClickDisclaimerEn,
+          },{
+            label: '上架須知和收費',
+            color: 'green',
+            variant: 'outline',
+            click: onClickDisclaimerZh,
+          }]"
+        />
+        <UDivider :label="`Steps ${step} / 4`" />
 
         <UCard
-          v-if="!iscnCreateData"
+          v-if="step === 1"
           :ui="{ body: { base: 'space-y-4' } }"
         >
-          <UFormGroup label="Enter ISCN ID or NFT Class ID">
-            <UInput
-              v-model="iscnIdInput"
+          <template #header>
+            <h2 class="font-bold font-mono">
+              1. Select or Create ISCN
+            </h2>
+          </template>
+
+          <UCard
+            v-if="!iscnCreateData"
+            :ui="{ body: { base: 'space-y-4' } }"
+          >
+            <UFormGroup label="Enter ISCN ID or NFT Class ID">
+              <UInput
+                v-model="iscnIdInput"
+                class="font-mono"
+                placeholder="iscn://... or likenft...."
+              />
+            </UFormGroup>
+
+            <UButton
+              type="submit"
+              label="Submit"
+              :disabled="isLoading || !(iscnIdInput)"
+              @click="onISCNIDInput"
+            />
+          </UCard>
+
+          <UDivider label="OR" />
+
+          <UCard :ui="{ body: { base: 'space-y-4' } }">
+            <UFormGroup>
+              <template #label>
+                Upload ISCN data json file
+                <UButton
+                  to="https://github.com/likecoin/iscn-nft-tools/blob/master/mint-nft/samples/iscn.json"
+                  :padded="false"
+                  variant="link"
+                  target="_blank"
+                >
+                  (iscn.json)
+                </UButton>
+              </template>
+              <UInput class="my-4" type="file" accept="application/json" @change="onISCNFileChange" />
+            </UFormGroup>
+            <UAlert
+              title=""
+              icon="i-heroicons-light-bulb"
+              color="primary"
+              variant="soft"
+            >
+              <template #title>
+                You can also create your ISCN using
+                <UButton
+                  :to="`${appLikeCoURL}/new`"
+                  :padded="false"
+                  variant="link"
+                  target="_blank"
+                >
+                  app.like.co
+                </UButton>
+              </template>
+            </UAlert>
+
+            <UTextarea
+              v-if="iscnCreateData"
+              :value="JSON.stringify(iscnCreateData, null, 2) "
+              cols="100"
+              :rows="10"
+              readonly
+            />
+
+            <UButton
+              label="Create"
+              :disabled="isLoading || !(iscnCreateData)"
+              @click="onISCNFileInput"
+            />
+          </UCard>
+        </UCard>
+        <UCard
+          v-else-if="step > 1"
+          :ui="{ body: { base: 'space-y-4' } }"
+        >
+          <template #header>
+            <h2 class="font-bold font-mono">
+              ISCN Information
+            </h2>
+          </template>
+
+          <UFormGroup label="ISCN ID">
+            <UButton
               class="font-mono"
-              placeholder="iscn://... or likenft...."
+              :label="iscnId"
+              :to="`${appLikeCoURL}/view/${encodeURIComponent(iscnId)}`"
+              target="_blank"
+              variant="link"
+              :padded="false"
             />
           </UFormGroup>
 
-          <UButton
-            type="submit"
-            label="Submit"
-            :disabled="isLoading || !(iscnIdInput)"
-            @click="onISCNIDInput"
-          />
-        </UCard>
-
-        <UDivider label="OR" />
-
-        <UCard :ui="{ body: { base: 'space-y-4' } }">
-          <UFormGroup>
-            <template #label>
-              Upload ISCN data json file
-              <UButton
-                to="https://github.com/likecoin/iscn-nft-tools/blob/master/mint-nft/samples/iscn.json"
-                :padded="false"
-                variant="link"
-                target="_blank"
-              >
-                (iscn.json)
-              </UButton>
-            </template>
-            <UInput class="my-4" type="file" accept="application/json" @change="onISCNFileChange" />
+          <UFormGroup label="ISCN Owner">
+            <UButton
+              :label="iscnOwner"
+              :to="`${likerLandURL}/${encodeURIComponent(iscnOwner)}`"
+              target="_blank"
+              variant="link"
+              :padded="false"
+            />
           </UFormGroup>
-          <UAlert
-            title=""
-            icon="i-heroicons-light-bulb"
-            color="primary"
-            variant="soft"
-          >
-            <template #title>
-              You can also create your ISCN using
-              <UButton
-                :to="`${appLikeCoURL}/new`"
-                :padded="false"
-                variant="link"
-                target="_blank"
-              >
-                app.like.co
-              </UButton>
-            </template>
-          </UAlert>
 
-          <UTextarea
-            v-if="iscnCreateData"
-            :value="JSON.stringify(iscnCreateData, null, 2) "
-            cols="100"
-            :rows="10"
-            readonly
-          />
-
+          <UFormGroup label="ISCN Title">
+            <UInput
+              :value="iscnData?.contentMetadata?.name"
+              :readonly="true"
+              variant="none"
+              :padded="false"
+            />
+          </UFormGroup>
+          <UFormGroup label="ISCN Description">
+            <UInput
+              :value="iscnData?.contentMetadata?.description"
+              :readonly="true"
+              variant="none"
+              :padded="false"
+            />
+          </UFormGroup>
           <UButton
-            label="Create"
-            :disabled="isLoading || !(iscnCreateData)"
-            @click="onISCNFileInput"
+            label="Edit ISCN Metadata"
+            @click="showEditISCNModal = true"
           />
         </UCard>
-      </UCard>
-      <UCard
-        v-else-if="step > 1"
-        :ui="{ body: { base: 'space-y-4' } }"
-      >
-        <template #header>
-          <h2 class="font-bold font-mono">
-            ISCN Information
-          </h2>
-        </template>
 
-        <UFormGroup label="ISCN ID">
-          <UButton
-            class="font-mono"
-            :label="iscnId"
-            :to="`${appLikeCoURL}/view/${encodeURIComponent(iscnId)}`"
-            target="_blank"
-            variant="link"
-            :padded="false"
-          />
-        </UFormGroup>
-
-        <UFormGroup label="ISCN Owner">
-          <UButton
-            :label="iscnOwner"
-            :to="`${likerLandURL}/${encodeURIComponent(iscnOwner)}`"
-            target="_blank"
-            variant="link"
-            :padded="false"
-          />
-        </UFormGroup>
-
-        <UFormGroup label="ISCN Title">
-          <UInput
-            :value="iscnData?.contentMetadata?.name"
-            :readonly="true"
-            variant="none"
-            :padded="false"
-          />
-        </UFormGroup>
-        <UFormGroup label="ISCN Description">
-          <UInput
-            :value="iscnData?.contentMetadata?.description"
-            :readonly="true"
-            variant="none"
-            :padded="false"
-          />
-        </UFormGroup>
-        <UButton
-          label="Edit ISCN Metadata"
-          @click="showEditISCNModal = true"
-        />
-      </UCard>
-
-      <UCard
-        v-if="step === 2 || step === 3"
-        :ui="{ body: { base: 'space-y-4' } }"
-      >
-        <template #header>
-          <h2 class="font-bold font-mono">
-            {{ step }}. {{ isCreatingClass ? 'Create NFT Class' : 'Mint NFT' }}
-          </h2>
-        </template>
-
-        <UTabs
-          class="w-full"
-          :items="[
-            { label: 'By filling required information', slot: 'input' },
-            { label: 'By uploading data files', slot: 'upload' },
-          ]"
+        <UCard
+          v-if="step === 2 || step === 3"
+          :ui="{ body: { base: 'space-y-4' } }"
         >
-          <template #upload>
-            <UCard :ui="{ body: { base: 'space-y-4' } }">
-              <template #header>
-                <h3 class="font-bold">
-                  Mint NFT by uploading data files
-                </h3>
-              </template>
-
-              <UFormGroup v-if="isCreatingClass" label="Max number of supply for this NFT Class (optional):">
-                <UInput
-                  v-model="classMaxSupply"
-                  type="number"
-                  :min="nftMintCount"
-                />
-              </UFormGroup>
-
-              <UFormGroup label="Number of NFT to mint:">
-                <UInput
-                  v-model="nftMintCount"
-                  type="number"
-                  :min="0"
-                  :max="mintMaxCount"
-                />
-              </UFormGroup>
-
-              <UFormGroup v-if="isCreatingClass">
-                <template #label>
-                  Upload NFT Class data JSON file (<UButton
-                    label="nft_class.json"
-                    to="https://github.com/likecoin/iscn-nft-tools/blob/master/mint-nft/samples/nft_class.json"
-                    variant="link"
-                    :padded="false"
-                    target="_blank"
-                  />)
-                </template>
-                <UInput type="file" accept="application/json" @change="onClassFileChange" />
-                <UTextarea
-                  v-if="classCreateData"
-                  :value="JSON.stringify(classCreateData, null, 2)"
-                  class="mt-2"
-                  cols="100"
-                  :rows="10"
-                  readonly
-                />
-              </UFormGroup>
-
-              <UFormGroup>
-                <template #label>
-                  Upload NFT default data JSON file<br>(<UButton
-                    label="nfts_default.json"
-                    to="https://github.com/likecoin/iscn-nft-tools/blob/master/mint-nft/samples/nfts_default.json"
-                    variant="link"
-                    :padded="false"
-                    target="_blank"
-                  />)
-                </template>
-                <UInput type="file" accept="application/json" @change="onMintNFTDefaultFileChange" />
-                <UTextarea
-                  v-if="nftMintDefaultData"
-                  :value="JSON.stringify(nftMintDefaultData, null, 2)"
-                  cols="100"
-                  :rows="10"
-                  readonly
-                />
-              </UFormGroup>
-
-              <UFormGroup>
-                <template #label>
-                  Upload NFT CSV file (<UButton
-                    label="nfts.csv"
-                    to="https://github.com/likecoin/iscn-nft-tools/blob/master/mint-nft/samples/nfts.csv"
-                    variant="link"
-                    :padded="false"
-                    target="_blank"
-                  />)
-                </template>
-                <UInput type="file" accept=".csv" @change="onMintNFTFileChange" />
-              </UFormGroup>
-
-              <UAlert
-                v-if="nftMintListData?.length"
-                :title="`Number of NFT data in CSV: ${nftMintListData?.length}`"
-              />
-
-              <template #footer>
-                <UButton
-                  label="Mint"
-                  :disabled="
-                    isLoading ||
-                      !(
-                        (!isCreatingClass || classCreateData) &&
-                        nftMintDefaultData &&
-                        nftMintListData
-                      )"
-                  @click="onClickMintByUploading"
-                />
-              </template>
-            </UCard>
+          <template #header>
+            <h2 class="font-bold font-mono">
+              {{ step }}. {{ isCreatingClass ? 'Create NFT Class' : 'Mint NFT' }}
+            </h2>
           </template>
 
-          <template #input>
-            <UCard
-              class="flex-1"
-              :ui="{ body: { base: 'space-y-4' } }"
-            >
-              <template #header>
-                <h3 class="font-bold">
-                  Mint NFT by filling required information
-                </h3>
-              </template>
-              <UForm :validate="validate" :state="state" class="flex flex-col gap-[12px]">
-                <UFormGroup label="NFT ID Prefix / 前綴（書本編號）" name="prefix" required>
-                  <UInput v-model="state.nftIdPrefix" placeholder="English only ex.MoneyVerse" />
-                </UFormGroup>
+          <UTabs
+            class="w-full"
+            :items="[
+              { label: 'By filling required information', slot: 'input' },
+              { label: 'By uploading data files', slot: 'upload' },
+            ]"
+          >
+            <template #upload>
+              <UCard :ui="{ body: { base: 'space-y-4' } }">
+                <template #header>
+                  <h3 class="font-bold">
+                    Mint NFT by uploading data files
+                  </h3>
+                </template>
 
-                <UFormGroup label="Number of NFT to mint / 鑄造數量（此批）" required>
-                  <UInput
-                    v-model="nftMintCount"
-                    placeholder="0-100"
-                    type="number"
-                    :min="0"
-                    :max="classMaxSupply"
-                  />
-                </UFormGroup>
-
-                <UFormGroup label="Image URL / 封面網址" required>
-                  <UInput v-model="imageUrl" placeholder="ipfs:// ... or ar://...." />
-                </UFormGroup>
-
-                <UFormGroup label="External URL (optional) / 外部網址（選填）">
-                  <UInput v-model="externalUrl" placeholder="https://" />
-                </UFormGroup>
-
-                <UFormGroup label="URI (optional) / 元資料網址（選填）">
-                  <UInput v-model="uri" placeholder="https://" />
-                </UFormGroup>
-
-                <UFormGroup v-if="isCreatingClass" label="Max number of supply for this NFT Class (optional) / 最大供應量（選填）">
-                  <template
-                    v-if="classMaxSupply && classMaxSupply < nftMintCount"
-                    #help
-                  >
-                    <UAlert
-                      class="mt-1"
-                      icon="i-heroicons-exclamation-triangle"
-                      title="Should be more than number of NFT to mint"
-                      color="red"
-                      variant="subtle"
-                    />
-                  </template>
+                <UFormGroup v-if="isCreatingClass" label="Max number of supply for this NFT Class (optional):">
                   <UInput
                     v-model="classMaxSupply"
                     type="number"
                     :min="nftMintCount"
-                    :placeholder="`> ${nftMintCount}`"
                   />
                 </UFormGroup>
-              </UForm>
-              <template #footer>
-                <UButton
-                  label="Mint"
-                  :disabled="isLoading || !(state.nftIdPrefix && nftMintCount && imageUrl) || hasError"
-                  @click="onClickMintByInputting"
+
+                <UFormGroup label="Number of NFT to mint:">
+                  <UInput
+                    v-model="nftMintCount"
+                    type="number"
+                    :min="0"
+                    :max="mintMaxCount"
+                  />
+                </UFormGroup>
+
+                <UFormGroup v-if="isCreatingClass">
+                  <template #label>
+                    Upload NFT Class data JSON file (<UButton
+                      label="nft_class.json"
+                      to="https://github.com/likecoin/iscn-nft-tools/blob/master/mint-nft/samples/nft_class.json"
+                      variant="link"
+                      :padded="false"
+                      target="_blank"
+                    />)
+                  </template>
+                  <UInput type="file" accept="application/json" @change="onClassFileChange" />
+                  <UTextarea
+                    v-if="classCreateData"
+                    :value="JSON.stringify(classCreateData, null, 2)"
+                    class="mt-2"
+                    cols="100"
+                    :rows="10"
+                    readonly
+                  />
+                </UFormGroup>
+
+                <UFormGroup>
+                  <template #label>
+                    Upload NFT default data JSON file<br>(<UButton
+                      label="nfts_default.json"
+                      to="https://github.com/likecoin/iscn-nft-tools/blob/master/mint-nft/samples/nfts_default.json"
+                      variant="link"
+                      :padded="false"
+                      target="_blank"
+                    />)
+                  </template>
+                  <UInput type="file" accept="application/json" @change="onMintNFTDefaultFileChange" />
+                  <UTextarea
+                    v-if="nftMintDefaultData"
+                    :value="JSON.stringify(nftMintDefaultData, null, 2)"
+                    cols="100"
+                    :rows="10"
+                    readonly
+                  />
+                </UFormGroup>
+
+                <UFormGroup>
+                  <template #label>
+                    Upload NFT CSV file (<UButton
+                      label="nfts.csv"
+                      to="https://github.com/likecoin/iscn-nft-tools/blob/master/mint-nft/samples/nfts.csv"
+                      variant="link"
+                      :padded="false"
+                      target="_blank"
+                    />)
+                  </template>
+                  <UInput type="file" accept=".csv" @change="onMintNFTFileChange" />
+                </UFormGroup>
+
+                <UAlert
+                  v-if="nftMintListData?.length"
+                  :title="`Number of NFT data in CSV: ${nftMintListData?.length}`"
                 />
-              </template>
-            </UCard>
+
+                <template #footer>
+                  <UButton
+                    label="Mint"
+                    :disabled="
+                      isLoading ||
+                        !(
+                          (!isCreatingClass || classCreateData) &&
+                          nftMintDefaultData &&
+                          nftMintListData
+                        )"
+                    @click="onClickMintByUploading"
+                  />
+                </template>
+              </UCard>
+            </template>
+
+            <template #input>
+              <UCard
+                class="flex-1"
+                :ui="{ body: { base: 'space-y-4' } }"
+              >
+                <template #header>
+                  <h3 class="font-bold">
+                    Mint NFT by filling required information
+                  </h3>
+                </template>
+                <UForm :validate="validate" :state="state" class="flex flex-col gap-[12px]">
+                  <UFormGroup label="NFT ID Prefix / 前綴（書本編號）" name="prefix" required>
+                    <UInput v-model="state.nftIdPrefix" placeholder="English only ex.MoneyVerse" />
+                  </UFormGroup>
+
+                  <UFormGroup label="Number of NFT to mint / 鑄造數量（此批）" required>
+                    <UInput
+                      v-model="nftMintCount"
+                      placeholder="0-100"
+                      type="number"
+                      :min="0"
+                      :max="classMaxSupply"
+                    />
+                  </UFormGroup>
+
+                  <UFormGroup label="Image URL / 封面網址" required>
+                    <UInput v-model="imageUrl" placeholder="ipfs:// ... or ar://...." />
+                  </UFormGroup>
+
+                  <UFormGroup label="External URL (optional) / 外部網址（選填）">
+                    <UInput v-model="externalUrl" placeholder="https://" />
+                  </UFormGroup>
+
+                  <UFormGroup label="URI (optional) / 元資料網址（選填）">
+                    <UInput v-model="uri" placeholder="https://" />
+                  </UFormGroup>
+
+                  <UFormGroup v-if="isCreatingClass" label="Max number of supply for this NFT Class (optional) / 最大供應量（選填）">
+                    <template
+                      v-if="classMaxSupply && classMaxSupply < nftMintCount"
+                      #help
+                    >
+                      <UAlert
+                        class="mt-1"
+                        icon="i-heroicons-exclamation-triangle"
+                        title="Should be more than number of NFT to mint"
+                        color="red"
+                        variant="subtle"
+                      />
+                    </template>
+                    <UInput
+                      v-model="classMaxSupply"
+                      type="number"
+                      :min="nftMintCount"
+                      :placeholder="`> ${nftMintCount}`"
+                    />
+                  </UFormGroup>
+                </UForm>
+                <template #footer>
+                  <UButton
+                    label="Mint"
+                    :disabled="isLoading || !(state.nftIdPrefix && nftMintCount && imageUrl) || hasError"
+                    @click="onClickMintByInputting"
+                  />
+                </template>
+              </UCard>
+            </template>
+          </UTabs>
+        </UCard>
+
+        <UCard v-else-if="step > 2 && classId">
+          <template #header>
+            <h3>NFT Class Information</h3>
           </template>
-        </UTabs>
-      </UCard>
 
-      <UCard v-else-if="step > 2 && classId">
-        <template #header>
-          <h3>NFT Class Information</h3>
-        </template>
-
-        <UFormGroup label="NFT Class ID">
-          <UButton
-            :label="classId"
-            :to="`${likerLandURL}/nft/class/${encodeURIComponent(classId)}`"
-            target="_blank"
-            variant="link"
-            :padded="false"
-          />
-        </UFormGroup>
-      </UCard>
-
-      <UCard
-        v-if="step > 3"
-        :ui="{
-          header: { base: 'font-bold font-mono' },
-          body: { base: 'flex flex-wrap items-center justify-center gap-2' },
-          footer: { base: 'flex flex-wrap items-center justify-end gap-2' },
-        }"
-      >
-        <template #header>
-          🎉 Success!
-        </template>
-
-        <UButton
-          label="Download NFT result csv"
-          :disabled="isLoading"
-          variant="outline"
-          @click="onDownloadCSV"
-        />
-
-        <template v-if="shouldShowDownloadLink">
-          <UButton
-            label="Download nft_class.json"
-            :disabled="isLoading"
-            variant="outline"
-            @click="onDownloadClassJSON"
-          />
-          <UButton
-            label="Download nft_default.json"
-            :disabled="isLoading"
-            variant="outline"
-            @click="onDownloadDefaultClassJSON"
-          />
-          <UButton
-            label="Download nfts.csv"
-            :disabled="isLoading"
-            variant="outline"
-            @click="onDownloadNftsCSV"
-          />
-        </template>
-
-        <template #footer>
-          <UButton
-            label="View your NFT"
-            variant="outline"
-            target="_blank"
-            :to="`${likerLandURL}/nft/class/${encodeURIComponent(classId)}`"
-          />
-          <div class="p-[4px] border-[2px] border-[#f59e0b] rounded-[0.375rem]">
+          <UFormGroup label="NFT Class ID">
             <UButton
-              :to="{ name: 'nft-book-store-new', query: { class_id: classId, count: nftMintCount } }"
-              label="Continue to publish NFT Book / 繼續上架"
-              variant="solid"
-              color="orange"
+              :label="classId"
+              :to="`${likerLandURL}/nft/class/${encodeURIComponent(classId)}`"
+              target="_blank"
+              variant="link"
+              :padded="false"
             />
-          </div>
-        </template>
-      </UCard>
+          </UFormGroup>
+        </UCard>
 
-      <UProgress v-if="isLoading" animation="carousel">
-        <template #indicator>
-          Loading...
-        </template>
-      </UProgress>
-      <EditISCNMetadataModal
-        ref="editISCNRef"
-        v-model="showEditISCNModal"
-        :class-id="classId"
-        @save="onSaveISCN"
-      />
+        <UCard
+          v-if="step > 3"
+          :ui="{
+            header: { base: 'font-bold font-mono' },
+            body: { base: 'flex flex-wrap items-center justify-center gap-2' },
+            footer: { base: 'flex flex-wrap items-center justify-end gap-2' },
+          }"
+        >
+          <template #header>
+            🎉 Success!
+          </template>
+
+          <UButton
+            label="Download NFT result csv"
+            :disabled="isLoading"
+            variant="outline"
+            @click="onDownloadCSV"
+          />
+
+          <template v-if="shouldShowDownloadLink">
+            <UButton
+              label="Download nft_class.json"
+              :disabled="isLoading"
+              variant="outline"
+              @click="onDownloadClassJSON"
+            />
+            <UButton
+              label="Download nft_default.json"
+              :disabled="isLoading"
+              variant="outline"
+              @click="onDownloadDefaultClassJSON"
+            />
+            <UButton
+              label="Download nfts.csv"
+              :disabled="isLoading"
+              variant="outline"
+              @click="onDownloadNftsCSV"
+            />
+          </template>
+
+          <template #footer>
+            <UButton
+              label="View your NFT"
+              variant="outline"
+              target="_blank"
+              :to="`${likerLandURL}/nft/class/${encodeURIComponent(classId)}`"
+            />
+            <div class="p-[4px] border-[2px] border-[#f59e0b] rounded-[0.375rem]">
+              <UButton
+                :to="{ name: 'nft-book-store-new', query: { class_id: classId, count: nftMintCount } }"
+                label="Continue to publish NFT Book / 繼續上架"
+                variant="solid"
+                color="orange"
+              />
+            </div>
+          </template>
+        </UCard>
+
+        <UProgress v-if="isLoading" animation="carousel">
+          <template #indicator>
+            Loading...
+          </template>
+        </UProgress>
+        <EditISCNMetadataModal
+          ref="editISCNRef"
+          v-model="showEditISCNModal"
+          :class-id="classId"
+          @save="onSaveISCN"
+        />
+      </AuthRequiredView>
     </PageBody>
   </PageContainer>
 </template>

--- a/pages/mint-nft/index.vue
+++ b/pages/mint-nft/index.vue
@@ -615,7 +615,10 @@ async function onISCNIDInput () {
         $fetch(`${LCD_URL}/cosmos/nft/v1beta1/classes/${encodeURIComponent(iscnIdInput.value)}`),
         $fetch(`${LIKE_CO_API}/likernft/book/store/${iscnIdInput.value}`)
       ])
-      if (!data || !classInfo) { throw new Error('INVALID_NFT_CLASS_ID') }
+      if (!data || !classInfo) {
+        isRestockingNFT.value = false
+        throw new Error('INVALID_NFT_CLASS_ID')
+      }
       classListingInfo.value = classInfo
       classData.value = (data as any).class
       const parentIscnId = classData.value?.data?.parent?.iscn_id_prefix

--- a/pages/mint-nft/index.vue
+++ b/pages/mint-nft/index.vue
@@ -436,7 +436,7 @@
                   params: { classId },
                   query: { count: nftMintCount }
                 }"
-                label="publish New Edition / 新庫存上架"
+                label="Restock existing listing/ 新庫存上架"
                 variant="solid"
                 color="orange"
               />
@@ -478,7 +478,7 @@ import { useWalletStore } from '~/stores/wallet'
 import { downloadFile, convertArrayOfObjectsToCSV, sleep } from '~/utils'
 import { NFT_DEFAULT_MINT_AMOUNT, PUBLISHING_NOTICE_URL_EN, PUBLISHING_NOTICE_URL_ZH } from '~/constant'
 
-const { LCD_URL, APP_LIKE_CO_URL, LIKER_LAND_URL } = useRuntimeConfig().public
+const { LCD_URL, APP_LIKE_CO_URL, LIKER_LAND_URL, LIKE_CO_API } = useRuntimeConfig().public
 const router = useRouter()
 const route = useRoute()
 
@@ -601,7 +601,10 @@ async function onISCNIDInput () {
       iscnOwner.value = owner
       step.value = 2
     } else if (iscnIdInput.value.startsWith('likenft')) {
-      isRestockingNFT.value = true
+      const existingListing = await fetch(`${LIKE_CO_API}/likernft/book/store/${iscnIdInput.value}`)
+      if (existingListing?.status === 200) {
+        isRestockingNFT.value = true
+      }
       const data = await $fetch(`${LCD_URL}/cosmos/nft/v1beta1/classes/${encodeURIComponent(iscnIdInput.value)}`)
       if (!data) {
         isRestockingNFT.value = false

--- a/pages/mint-nft/index.vue
+++ b/pages/mint-nft/index.vue
@@ -432,10 +432,9 @@
               <UButton
                 v-if="isRestockingNFT"
                 :to="{
-                  name: 'nft-book-store-status-classId-edit-new',
+                  name: 'nft-book-store-status-classId',
                   params: { classId },
-                  query: { priceIndex: editionIndex,count: nftMintCount },
-
+                  query: { count: nftMintCount }
                 }"
                 label="publish New Edition / 新庫存上架"
                 variant="solid"
@@ -479,7 +478,7 @@ import { useWalletStore } from '~/stores/wallet'
 import { downloadFile, convertArrayOfObjectsToCSV, sleep } from '~/utils'
 import { NFT_DEFAULT_MINT_AMOUNT, PUBLISHING_NOTICE_URL_EN, PUBLISHING_NOTICE_URL_ZH } from '~/constant'
 
-const { LCD_URL, APP_LIKE_CO_URL, LIKER_LAND_URL, LIKE_CO_API } = useRuntimeConfig().public
+const { LCD_URL, APP_LIKE_CO_URL, LIKER_LAND_URL } = useRuntimeConfig().public
 const router = useRouter()
 const route = useRoute()
 
@@ -527,14 +526,6 @@ const showEditISCNModal = ref(false)
 const editISCNRef = ref<any>(null)
 
 const isRestockingNFT = ref(false)
-const classListingInfo = ref<any>(null)
-
-const editionIndex = computed(() => {
-  if (classListingInfo.value) {
-    return classListingInfo.value.prices.length
-  }
-  return 1
-})
 
 watch(iscnId, (newIscnId) => {
   if (newIscnId) {
@@ -611,15 +602,11 @@ async function onISCNIDInput () {
       step.value = 2
     } else if (iscnIdInput.value.startsWith('likenft')) {
       isRestockingNFT.value = true
-      const [data, classInfo] = await Promise.all([
-        $fetch(`${LCD_URL}/cosmos/nft/v1beta1/classes/${encodeURIComponent(iscnIdInput.value)}`),
-        $fetch(`${LIKE_CO_API}/likernft/book/store/${iscnIdInput.value}`)
-      ])
-      if (!data || !classInfo) {
+      const data = await $fetch(`${LCD_URL}/cosmos/nft/v1beta1/classes/${encodeURIComponent(iscnIdInput.value)}`)
+      if (!data) {
         isRestockingNFT.value = false
         throw new Error('INVALID_NFT_CLASS_ID')
       }
-      classListingInfo.value = classInfo
       classData.value = (data as any).class
       const parentIscnId = classData.value?.data?.parent?.iscn_id_prefix
       const resISCN = await $fetch(`${LCD_URL}/iscn/records/id?iscn_id=${encodeURIComponent(parentIscnId)}`)

--- a/pages/mint-nft/index.vue
+++ b/pages/mint-nft/index.vue
@@ -436,7 +436,7 @@
                   params: { classId },
                   query: { count: nftMintCount }
                 }"
-                label="Restock existing listing/ 新庫存上架"
+                label="Restock existing listing / 新庫存上架"
                 variant="solid"
                 color="orange"
               />
@@ -594,6 +594,7 @@ function onClickDisclaimerZh () {
 async function onISCNIDInput () {
   try {
     isLoading.value = true
+    isRestockingNFT.value = false
     if (iscnIdInput.value.startsWith('iscn://')) {
       const data = await $fetch(`${LCD_URL}/iscn/records/id?iscn_id=${encodeURIComponent(iscnIdInput.value)}`)
       const { records, owner } = data as any


### PR DESCRIPTION
- [Should remind user to signin first](https://www.notion.so/likecoin/Should-remind-user-to-signin-first-1ca6658c4c68807aa84cecb10d84f256?pvs=4) -> [🚸 Add auth check for /mint-nft](https://github.com/likecoin/nft-book-press/commit/1251d9e4b8710a29dbc458e1d4dc07600cd093a1)
- [不需支持 Book 以外的媒介](https://www.notion.so/likecoin/Book-1cf6658c4c6880caa641dd8f1a63dd36?pvs=4) -> [🎨 Remove unused type options](https://github.com/likecoin/nft-book-press/commit/3d990900df9d9e1e0652dd25bfa4104a81302650)
- [預設 publication date 為今天](https://www.notion.so/likecoin/publication-date-1cf6658c4c688034ae30c0d7357e2b70?pvs=4) -> [🎨 Set default publication date to today's date](https://github.com/likecoin/nft-book-press/commit/b48a62f84f53d3ef6249c829ebfc6d82c47f7837)
- [建議提示訊息調整顏色](https://www.notion.so/likecoin/1ce6658c4c688008981fe3632557dad1?pvs=4) -> [🚸 Change toast color for ISCN update success message](https://github.com/likecoin/nft-book-press/commit/588108a9c570e68cabf7c7def3930ac29552e0a6)
- [不能補書上架](https://www.notion.so/likecoin/1ce6658c4c688097b379c7983eab19e9?pvs=4) -> [🚸 Add restocking handling for classId input](https://github.com/likecoin/nft-book-press/commit/7d90d0871ba686cb2086b338309df9ed75558f0a)

For classId case in `/mint-nft`, redirect to `classId/edit/new` to complete the restocking process.
![截圖 2025-04-15 21 14 52](https://github.com/user-attachments/assets/2bc436ab-a1e7-4bfd-9999-f828afdfb1c2)
![截圖 2025-04-15 21 13 52](https://github.com/user-attachments/assets/4ad30f0c-9a40-41b9-b0cc-992b6adb57dd)
