### PR TITLE
🐛 Fix edition index display for edit & new edition modes

### DIFF
--- a/components/NewNFTBook.vue
+++ b/components/NewNFTBook.vue
@@ -41,7 +41,7 @@
                 <div class="flex items-center justify-between">
                   <h3
                     class="font-bold font-mono"
-                    v-text="`${$t('nft_book_form.edition_number', { number: index + 1 })} - ${p.name || $t('nft_book_form.product_name_placeholder')}`"
+                    v-text="`${$t('nft_book_form.edition_number', { number: (displayEditIndex || (index + 1)) })} - ${p.name || $t('nft_book_form.product_name_placeholder')}`"
                   />
                   <div class="flex items-center gap-2">
                     <p class="text-sm" v-text="$t('nft_book_form.pause_selling')" />
@@ -416,6 +416,13 @@ const props = defineProps({
   classId: { type: String, default: '' },
   editionIndex: { type: [String, Number], default: undefined },
   isEditMode: { type: Boolean, default: false }
+})
+
+const displayEditIndex = computed(() => {
+  if (props.editionIndex !== undefined) {
+    return Number(props.editionIndex) + 1
+  }
+  return undefined
 })
 
 useSeoMeta({


### PR DESCRIPTION
when editing # 4
before
<img width="1113" height="660" alt="截圖 2025-09-19 16 13 02" src="https://github.com/user-attachments/assets/eb8c1701-f0cc-419c-8f32-4103f182f7b2" />
after
<img width="987" height="749" alt="截圖 2025-09-19 16 12 40" src="https://github.com/user-attachments/assets/2ecf6d38-0bf8-41b2-a95d-55281766782f" />
