### PR TITLE
🐛 Normalize class ID to lowercase after parsing NewBookNFT event

### DIFF
--- a/composables/useNFTClassCreator.ts
+++ b/composables/useNFTClassCreator.ts
@@ -76,7 +76,7 @@ export function useNFTClassCreator () {
       strict: false
     })
 
-    const classId = (bookNFTLog?.args as unknown as { bookNFT: string })?.bookNFT
+    const classId = (bookNFTLog?.args as unknown as { bookNFT: string })?.bookNFT?.toLowerCase()
     if (!classId) {
       throw new Error('NewBookNFT event not found in receipt')
     }


### PR DESCRIPTION
The contract address returned from the event log may be checksummed (mixed-case), causing mismatches with APIs and routes that expect lowercase class IDs.