### PR TITLE
🐛 Fix bulk upload resume alert lingering after reset

### DIFF
--- a/pages/bulk-upload.vue
+++ b/pages/bulk-upload.vue
@@ -826,6 +826,7 @@ function resumeSession () {
   const session = loadBulkUploadSession()
   if (!session) { return }
 
+  hasExistingSession.value = false
   books.value = restoreBooksFromSession(session)
 
   // If all books have their Arweave uploads done, go straight to processing
@@ -843,6 +844,7 @@ function resumeSession () {
 
 function clearAndStartNew () {
   clearBulkUploadSession()
+  hasExistingSession.value = false
   resetAll()
 }
 


### PR DESCRIPTION
hasExistingSession was only sampled in onMounted, so clicking Start New cleared the session but left the alert rendered over the fresh CSV step, making the button appear broken. Reset the flag in both clearAndStartNew and resumeSession so the alert dismisses correctly.