### PR TITLE
🐛 Fix Intercom user_id mismatch by gating on likerId

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -59,7 +59,7 @@
 </template>
 
 <script setup lang="ts">
-const { t: $t } = useI18n()
+const { t: $t, locale } = useI18n()
 
 const { SITE_URL } = useRuntimeConfig().public
 const { isShowMaintenancePage } = useMaintenanceMode()
@@ -68,8 +68,25 @@ const bookstoreApiStore = useBookstoreApiStore()
 const { restoreAuthSession, fetchBookListing, clearSession } = bookstoreApiStore
 const { wallet, intercomToken, isAuthenticated } = storeToRefs(bookstoreApiStore)
 const { isAuthenticating, loginStatus, authenticateByConnectorId, authenticateBySignature } = useAuth()
+const userStore = useUserStore()
+const { userLikerInfo } = storeToRefs(userStore)
 const uiStore = useUIStore()
 const toast = useToast()
+
+// Re-identify once likerId is known — see `useSetLogUser` for why it's
+// gated on likerId rather than the wallet.
+watch(() => userLikerInfo.value?.user, (likerId) => {
+  if (!isAuthenticated.value || !wallet.value || !likerId) { return }
+  const info = userLikerInfo.value!
+  useSetLogUser(wallet.value, {
+    likerId,
+    displayName: info.displayName,
+    likeWallet: info.likeWallet,
+    avatar: info.avatar,
+    locale: locale.value,
+    intercomToken: intercomToken.value
+  })
+})
 
 const isRestoringSession = ref(false)
 

--- a/app.vue
+++ b/app.vue
@@ -73,12 +73,16 @@ const { userLikerInfo } = storeToRefs(userStore)
 const uiStore = useUIStore()
 const toast = useToast()
 
-// Re-identify once likerId is known — see `useSetLogUser` for why it's
-// gated on likerId rather than the wallet.
+// Re-identify Intercom once likerId is known. Intercom's identity
+// verification requires `user_id === likerId` (see `useSetLogUser`), so
+// this path only fires after the liker info store has hydrated and the
+// JWT is available. Sentry/PostHog were already identified at login and
+// are intentionally left alone here to avoid overwriting fields like
+// `email` with undefined.
 watch(() => userLikerInfo.value?.user, (likerId) => {
-  if (!isAuthenticated.value || !wallet.value || !likerId) { return }
+  if (!isAuthenticated.value || !wallet.value || !likerId || !intercomToken.value) { return }
   const info = userLikerInfo.value!
-  useSetLogUser(wallet.value, {
+  useSetIntercomUser(wallet.value, {
     likerId,
     displayName: info.displayName,
     likeWallet: info.likeWallet,
@@ -145,7 +149,7 @@ onMounted(async () => {
   try {
     await restoreAuthSession()
     if (isAuthenticated.value && wallet.value) {
-      useSetLogUser(wallet.value, { intercomToken: intercomToken.value })
+      useSetLogUser(wallet.value)
     }
   } catch (error) {
     console.error(error)

--- a/app.vue
+++ b/app.vue
@@ -74,11 +74,11 @@ const uiStore = useUIStore()
 const toast = useToast()
 
 // Re-identify Intercom once likerId is known. Intercom's identity
-// verification requires `user_id === likerId` (see `useSetLogUser`), so
-// this path only fires after the liker info store has hydrated and the
-// JWT is available. Sentry/PostHog were already identified at login and
-// are intentionally left alone here to avoid overwriting fields like
-// `email` with undefined.
+// verification requires `user_id === likerId` (see `useSetIntercomUser`),
+// so this path only fires after the liker info store has hydrated and
+// the JWT is available. Sentry/PostHog were already identified at login
+// and are intentionally left alone here to avoid overwriting fields
+// like `email` with undefined.
 watch(() => userLikerInfo.value?.user, (likerId) => {
   if (!isAuthenticated.value || !wallet.value || !likerId || !intercomToken.value) { return }
   const info = userLikerInfo.value!

--- a/composables/useAuth.ts
+++ b/composables/useAuth.ts
@@ -4,7 +4,6 @@ export function useAuth () {
   const { wallet, isConnected } = storeToRefs(store)
   const { connect, disconnect, signMessageMemo } = store
   const { authenticate, clearSession, fetchBookListing } = bookstoreApiStore
-  const { intercomToken } = storeToRefs(bookstoreApiStore)
   const { showErrorToast } = useToastComposable()
   const { t: $t } = useI18n()
 
@@ -24,7 +23,7 @@ export function useAuth () {
       isAuthenticating.value = true
 
       await authenticate(signature.wallet, signature)
-      useSetLogUser(signature.wallet, { email: context?.email, intercomToken: intercomToken.value })
+      useSetLogUser(signature.wallet, { email: context?.email })
       useLogEvent('login', { method: signature.signMethod, wallet: signature.wallet })
       loginStatus.value = $t('auth_state.success')
       try {

--- a/composables/useLogEvent.ts
+++ b/composables/useLogEvent.ts
@@ -42,6 +42,7 @@ export const INTERCOM_TRACKED_EVENTS: ReadonlySet<string> = new Set([
   'stripe_setup_started',
   'stripe_login'
 ])
+const INTERCOM_SESSION_DURATION_MS = 30 * 24 * 60 * 60 * 1000
 
 interface EventParams {
   [key: string]: unknown
@@ -89,9 +90,18 @@ export function useLogEvent (eventName: string, eventParams: EventParams = {}) {
 
 export function useSetLogUser (
   wallet: string | null,
-  options: { email?: string; displayName?: string; intercomToken?: string } = {}
+  options: {
+    email?: string
+    displayName?: string
+    likerId?: string
+    likeWallet?: string
+    avatar?: string
+    locale?: string
+    intercomToken?: string
+  } = {}
 ) {
-  const { email, displayName, intercomToken } = options
+  const { email, displayName, likerId, likeWallet, avatar, locale, intercomToken } = options
+  const nameFallback = displayName || wallet || likeWallet
 
   // Set user in Sentry
   if (!wallet) {
@@ -100,27 +110,38 @@ export function useSetLogUser (
     setSentryUser({
       id: wallet,
       email,
-      username: displayName || wallet
+      username: nameFallback
     })
   }
 
-  // Set user in Intercom
+  // Set user in Intercom.
+  //
+  // The identity-verification JWT is signed with the LikeCoin user id as
+  // `user_id`, so the client-supplied `user_id` must equal `likerId` or
+  // Intercom rejects with UserIdMismatchException. Identification is
+  // therefore deferred until `likerId` is known — the `userLikerInfo`
+  // watcher in `app.vue` fires this path after the store has hydrated.
   if (window?.Intercom) {
     try {
       if (!wallet) {
         window.Intercom('shutdown')
-      } else {
-        const intercomData: Record<string, unknown> = {
-          user_id: wallet,
-          evm_wallet: wallet,
+      } else if (likerId) {
+        window.Intercom('update', {
+          intercom_user_jwt: intercomToken,
+          session_duration: INTERCOM_SESSION_DURATION_MS,
+          user_id: likerId,
           email,
-          name: displayName || wallet
-        }
-        if (intercomToken) {
-          intercomData.intercom_user_jwt = intercomToken
-          intercomData.session_duration = 2592000000 // 30d
-        }
-        window.Intercom('update', intercomData)
+          name: nameFallback,
+          avatar: avatar
+            ? {
+                type: 'avatar',
+                image_url: avatar
+              }
+            : undefined,
+          evm_wallet: wallet,
+          like_wallet: likeWallet,
+          locale
+        })
       }
     } catch (error) {
       console.error('Failed to set user data in Intercom', error)
@@ -137,7 +158,8 @@ export function useSetLogUser (
       } else {
         posthog.identify(wallet, {
           email: email || undefined,
-          name: displayName || wallet
+          name: nameFallback,
+          locale
         })
       }
     } catch (error) {

--- a/composables/useLogEvent.ts
+++ b/composables/useLogEvent.ts
@@ -88,7 +88,7 @@ export function useLogEvent (eventName: string, eventParams: EventParams = {}) {
   }
 }
 
-export function useSetLogUser (
+export function useSetIntercomUser (
   wallet: string | null,
   options: {
     email?: string
@@ -100,7 +100,49 @@ export function useSetLogUser (
     intercomToken?: string
   } = {}
 ) {
-  const { email, displayName, likerId, likeWallet, avatar, locale, intercomToken } = options
+  // The identity-verification JWT is signed with the LikeCoin user id as
+  // `user_id`, so the client-supplied `user_id` must equal `likerId` or
+  // Intercom rejects with UserIdMismatchException. Callers should only
+  // invoke this once both `likerId` and `intercomToken` are known.
+  if (!window?.Intercom) { return }
+  try {
+    if (!wallet) {
+      window.Intercom('shutdown')
+      return
+    }
+    const { email, displayName, likerId, likeWallet, avatar, locale, intercomToken } = options
+    if (!likerId || !intercomToken) { return }
+    window.Intercom('update', {
+      intercom_user_jwt: intercomToken,
+      session_duration: INTERCOM_SESSION_DURATION_MS,
+      user_id: likerId,
+      email,
+      name: displayName || wallet || likeWallet,
+      avatar: avatar
+        ? {
+            type: 'avatar',
+            image_url: avatar
+          }
+        : undefined,
+      evm_wallet: wallet,
+      like_wallet: likeWallet,
+      locale
+    })
+  } catch (error) {
+    console.error('Failed to set user data in Intercom', error)
+  }
+}
+
+export function useSetLogUser (
+  wallet: string | null,
+  options: {
+    email?: string
+    displayName?: string
+    likeWallet?: string
+    locale?: string
+  } = {}
+) {
+  const { email, displayName, likeWallet, locale } = options
   const nameFallback = displayName || wallet || likeWallet
 
   // Set user in Sentry
@@ -114,38 +156,11 @@ export function useSetLogUser (
     })
   }
 
-  // Set user in Intercom.
-  //
-  // The identity-verification JWT is signed with the LikeCoin user id as
-  // `user_id`, so the client-supplied `user_id` must equal `likerId` or
-  // Intercom rejects with UserIdMismatchException. Identification is
-  // therefore deferred until `likerId` is known — the `userLikerInfo`
-  // watcher in `app.vue` fires this path after the store has hydrated.
-  if (window?.Intercom) {
-    try {
-      if (!wallet) {
-        window.Intercom('shutdown')
-      } else if (likerId) {
-        window.Intercom('update', {
-          intercom_user_jwt: intercomToken,
-          session_duration: INTERCOM_SESSION_DURATION_MS,
-          user_id: likerId,
-          email,
-          name: nameFallback,
-          avatar: avatar
-            ? {
-                type: 'avatar',
-                image_url: avatar
-              }
-            : undefined,
-          evm_wallet: wallet,
-          like_wallet: likeWallet,
-          locale
-        })
-      }
-    } catch (error) {
-      console.error('Failed to set user data in Intercom', error)
-    }
+  // Intercom identify is deferred to `useSetIntercomUser` (needs likerId
+  // + JWT), but logout can shut it down here so callers don't have to
+  // coordinate both functions on reset.
+  if (!wallet) {
+    useSetIntercomUser(null)
   }
 
   // Set user in PostHog


### PR DESCRIPTION
The identity-verification JWT is signed with the LikeCoin user id, so the client-supplied user_id must equal likerId or Intercom rejects with UserIdMismatchException. Defer Intercom identification until userLikerInfo hydrates, and align the update payload (avatar, like_wallet, locale, name fallback) with liker-land-v3.