### PR TITLE
⬆️ Switch to @likecoin/wagmi-magic-connector and drop circular-ref hack

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@likecoin/epub-ts": "^0.6.3",
     "@likecoin/epubcheck-ts": "^0.6.0",
     "@likecoin/qr-code-styling": "^1.6.6",
-    "@likecoin/wagmi-connector": "2.4.0-like.0",
+    "@likecoin/wagmi-magic-connector": "^2.4.1",
     "@metamask/connect-evm": "~0.9.0",
     "@nuxt/ui": "3.3.7",
     "@pinia/nuxt": "^0.11.1",

--- a/utils/wagmi/config.ts
+++ b/utils/wagmi/config.ts
@@ -1,7 +1,7 @@
 import { http, createConfig, type Config, type CreateConnectorFn } from '@wagmi/core'
 import { base, baseSepolia } from '@wagmi/vue/chains'
 import { injected, metaMask, walletConnect, coinbaseWallet } from '@wagmi/vue/connectors'
-import { dedicatedWalletConnector } from '@likecoin/wagmi-connector'
+import { dedicatedWalletConnector } from '@likecoin/wagmi-magic-connector'
 
 export function createWagmiConfig ({
   apiKey,
@@ -23,6 +23,26 @@ export function createWagmiConfig ({
   const connectors: CreateConnectorFn[] = [
     injected(),
     metaMask(),
+    // `@likecoin/wagmi-magic-connector` hasn't been republished against
+    // `@wagmi/core` 3.x's tightened `connect()` return type (readonly accounts
+    // + `withCapabilities` generic). Runtime shape is compatible.
+    dedicatedWalletConnector({
+      chains: [chain],
+      options: {
+        apiKey,
+        accentColor: '#131313',
+        customHeaderText: '3ook.com',
+        customLogo: logoURL,
+        isDarkMode: false,
+        magicSdkConfiguration: {
+          deferPreload: true,
+          network: {
+            rpcUrl: chain.rpcUrls.default.http[0],
+            chainId: chain.id
+          }
+        }
+      }
+    }) as unknown as CreateConnectorFn,
     coinbaseWallet({
       appName: '3ook.com',
       appLogoUrl: logoURL
@@ -41,36 +61,6 @@ export function createWagmiConfig ({
           }
         }))
     }
-    const magicConnectorFn = dedicatedWalletConnector({
-      chains: [chain],
-      options: {
-        apiKey,
-        accentColor: '#131313',
-        customHeaderText: '3ook.com',
-        customLogo: logoURL,
-        isDarkMode: false,
-        magicSdkConfiguration: {
-          deferPreload: true,
-          network: {
-            rpcUrl: chain.rpcUrls.default.http[0],
-            chainId: chain.id
-          }
-        }
-      }
-    }) as CreateConnectorFn
-    // Wrap to make 'magic' non-enumerable on the connector object.
-    // Magic SDK instances have circular references (module.sdk → magic),
-    // and wagmi's deepEqual in getConnections() blows the stack traversing them.
-    connectors.push((config) => {
-      const connector = magicConnectorFn(config)
-      Object.defineProperty(connector, 'magic', {
-        value: undefined,
-        writable: true,
-        enumerable: false,
-        configurable: true
-      })
-      return connector
-    })
   }
 
   return createConfig({

--- a/yarn.lock
+++ b/yarn.lock
@@ -1862,10 +1862,10 @@
   dependencies:
     qrcode-generator "^1.4.3"
 
-"@likecoin/wagmi-connector@2.4.0-like.0":
-  version "2.4.0-like.0"
-  resolved "https://registry.yarnpkg.com/@likecoin/wagmi-connector/-/wagmi-connector-2.4.0-like.0.tgz#cc30ce210c73b1fced64d5e5f834981cddcac5dd"
-  integrity sha512-+hncq9Xwok9k+mosma+NxjFmzC2rsoAxP5D3Lot6bkQlx0yNwbxutT7MtThYyFPuzGQv1kfhImo8ivA/bkNsWA==
+"@likecoin/wagmi-magic-connector@^2.4.1":
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/@likecoin/wagmi-magic-connector/-/wagmi-magic-connector-2.4.1.tgz#e4d68e71445dbea1c9c2d65ebcd6b23935818d3a"
+  integrity sha512-Fo4J4uAPO0kZXVSInjXKYB6p7A1SMd2mUl9NRwQ1TM8rAACYIvhsDQokMbrbPk0nlmaAvDrqvs1jN5voG5Z75A==
   dependencies:
     "@magic-ext/evm" "^1.2.1"
     "@magic-ext/oauth2" "^15.3.1"


### PR DESCRIPTION
The renamed package ships the Magic SDK circular-reference fix upstream, so the non-enumerable `magic` workaround added in 2caeb4841 is no longer needed. Also allows the connector to run unconditionally (SSR-safe).