### PR TITLE
🔧 Disable bundle/proxy for @nuxt/scripts GA registry

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -31,6 +31,8 @@ export default defineNuxtConfig({
     registry: {
       intercom: true,
       googleAnalytics: {
+        bundle: false,
+        proxy: false,
         id: GA_TRACKING_ID || 'placeholder_id_to_avoid_nuxt_module_error',
         trigger: 'onNuxtReady'
       },


### PR DESCRIPTION
Load GA directly from Google's CDN instead of bundling or proxying the script through the app.