### PR TITLE
🐛 Fix DRM-free fingerprint URL in bulk upload

### DIFF
--- a/composables/useBulkUpload.ts
+++ b/composables/useBulkUpload.ts
@@ -177,7 +177,9 @@ export function useBulkUpload () {
 
     const ebookFile = book.epubFile || book.pdfFile
     const fileType = book.epubFilename ? 'epub' : 'pdf'
-    const arweaveLink = book.bookArweaveLink || `ar://${book.bookArweaveId}`
+    const arweaveLink = book.bookArweaveKey
+      ? book.bookArweaveLink || `ar://${book.bookArweaveId}`
+      : `ar://${book.bookArweaveId}`
 
     const contentFingerprints = [
       { url: `ar://${book.coverArweaveId}` },


### PR DESCRIPTION
Bulk upload always wrote the backend API URL as the ISCN contentFingerprint and downloadableUrls, even for DRM-free books. Mirror the single-upload logic so non-encrypted books use ar:// and only encrypted books fall back to the backend link.