### PR TITLE
🐛 Detect bulk upload ebook type from file content

### DIFF
--- a/composables/useBulkUpload.ts
+++ b/composables/useBulkUpload.ts
@@ -2,6 +2,7 @@ import type { BulkUploadBook } from '~/types/bulk-upload'
 import { BookUploadStatus } from '~/types/bulk-upload'
 import { NFT_DEFAULT_MINT_AMOUNT } from '~/constant'
 import type { NFTTokenMetadata } from '~/composables/useNFTMinter'
+import { detectEbookType } from '~/utils/ebookType'
 
 interface ProcessingCallbacks {
   onStatusChange?: (bookId: string, status: BookUploadStatus, message?: string) => void
@@ -126,10 +127,18 @@ export function useBulkUpload () {
       }
 
       currentStep.value = 'uploading_ebook'
+      const arrayBuffer = await ebookFile.arrayBuffer()
+      const detectedType = detectEbookType(arrayBuffer)
+      if (!detectedType) {
+        throw new Error(`File ${ebookFile.name} is not a valid PDF or EPUB`)
+      }
+      book.detectedFileType = detectedType
+      onProgress?.(book.id, { detectedFileType: detectedType })
+
       const bookPrepare = await prepareArweaveUpload({
-        arrayBuffer: await ebookFile.arrayBuffer(),
+        arrayBuffer,
         fileSize: ebookFile.size,
-        fileType: ebookFile.type,
+        fileType: detectedType === 'epub' ? 'application/epub+zip' : 'application/pdf',
         encrypt: book.enableDRM,
         sponsored
       })
@@ -176,7 +185,7 @@ export function useBulkUpload () {
     currentStep.value = 'creating_nft_class'
 
     const ebookFile = book.epubFile || book.pdfFile
-    const fileType = book.epubFilename ? 'epub' : 'pdf'
+    const fileType = book.detectedFileType ?? (book.epubFilename ? 'epub' : 'pdf')
     const arweaveLink = book.bookArweaveKey
       ? book.bookArweaveLink || `ar://${book.bookArweaveId}`
       : `ar://${book.bookArweaveId}`

--- a/types/bulk-upload.ts
+++ b/types/bulk-upload.ts
@@ -1,3 +1,5 @@
+import type { EbookType } from '~/utils/ebookType'
+
 export enum BookUploadStatus {
   PENDING = 'pending',
   UPLOADING_FILES = 'uploading',
@@ -70,6 +72,7 @@ export interface BulkUploadBook {
   coverFile?: File
   pdfFile?: File
   epubFile?: File
+  detectedFileType?: EbookType
   // Progress tracking (persisted for resume)
   coverArweaveId?: string
   coverIpfsHash?: string
@@ -105,6 +108,7 @@ export interface SerializedBulkUploadBook {
   status: BookUploadStatus
   error?: string
   // Progress tracking
+  detectedFileType?: EbookType
   coverArweaveId?: string
   coverIpfsHash?: string
   bookArweaveId?: string

--- a/utils/bulk-upload.ts
+++ b/utils/bulk-upload.ts
@@ -184,6 +184,7 @@ export function serializeBook (book: BulkUploadBook): SerializedBulkUploadBook {
     language: book.language,
     status: book.status,
     error: book.error,
+    detectedFileType: book.detectedFileType,
     coverArweaveId: book.coverArweaveId,
     coverIpfsHash: book.coverIpfsHash,
     bookArweaveId: book.bookArweaveId,

--- a/utils/ebookType.ts
+++ b/utils/ebookType.ts
@@ -1,0 +1,42 @@
+export type EbookType = 'pdf' | 'epub'
+
+const PDF_MAGIC = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2D])
+const ZIP_LOCAL_HEADER = new Uint8Array([0x50, 0x4B, 0x03, 0x04])
+const EPUB_MIMETYPE = 'application/epub+zip'
+
+function startsWith (bytes: Uint8Array, prefix: Uint8Array): boolean {
+  if (bytes.length < prefix.length) { return false }
+  for (let i = 0; i < prefix.length; i++) {
+    if (bytes[i] !== prefix[i]) { return false }
+  }
+  return true
+}
+
+// EPUB OCF spec mandates the first ZIP entry is `mimetype`, stored uncompressed,
+// with content `application/epub+zip` — so reading the local file header is enough.
+export function detectEbookType (buffer: ArrayBuffer): EbookType | null {
+  const bytes = new Uint8Array(buffer)
+
+  if (startsWith(bytes, PDF_MAGIC)) { return 'pdf' }
+
+  if (startsWith(bytes, ZIP_LOCAL_HEADER)) {
+    if (bytes.length < 30) { return null }
+    const compressionMethod = bytes[8]! | (bytes[9]! << 8)
+    if (compressionMethod !== 0) { return null }
+
+    const filenameLength = bytes[26]! | (bytes[27]! << 8)
+    const extraLength = bytes[28]! | (bytes[29]! << 8)
+    const filenameStart = 30
+    const filenameEnd = filenameStart + filenameLength
+    const contentStart = filenameEnd + extraLength
+    const contentEnd = contentStart + EPUB_MIMETYPE.length
+
+    if (bytes.length < contentEnd) { return null }
+
+    const decoder = new TextDecoder()
+    if (decoder.decode(bytes.subarray(filenameStart, filenameEnd)) !== 'mimetype') { return null }
+    if (decoder.decode(bytes.subarray(contentStart, contentEnd)) === EPUB_MIMETYPE) { return 'epub' }
+  }
+
+  return null
+}


### PR DESCRIPTION
Use magic bytes to determine whether each ebook is PDF or EPUB so the Arweave Content-Type tag and ISCN metadata reflect the actual content, not the (browser-inferred) file extension. Reject files that aren't a valid PDF or EPUB instead of uploading them with a misleading MIME tag.