### PR TITLE
🐛 Prevent duplicate NFT mint in bulk upload

### DIFF
--- a/app/composables/useBulkUpload.ts
+++ b/app/composables/useBulkUpload.ts
@@ -1,3 +1,4 @@
+import { getTransactionReceipt } from '@wagmi/vue/actions'
 import type { BulkUploadBook } from '~/types/bulk-upload'
 import { BookUploadStatus } from '~/types/bulk-upload'
 import type { BookPriceInDecimalByCurrency } from '~/types'
@@ -22,6 +23,7 @@ export function useBulkUpload() {
   const { createNFTClass } = useNFTClassCreator()
   const { mintNFT } = useNFTMinter()
   const { BOOK3_URL } = useRuntimeConfig().public
+  const { $wagmiConfig } = useNuxtApp()
 
   const isProcessing = ref(false)
   const currentBook = ref<BulkUploadBook | null>(null)
@@ -55,11 +57,9 @@ export function useBulkUpload() {
         await createNFTClassForBook(book, callbacks)
       }
 
-      // Step 3: Mint NFT
-      if (!book.mintTxHash) {
-        onStatusChange?.(book.id, BookUploadStatus.MINTING)
-        await mintNFTForBook(book, callbacks)
-      }
+      // Step 3: Mint NFT (mintNFTForBook is idempotent — see its receipt check)
+      onStatusChange?.(book.id, BookUploadStatus.MINTING)
+      await mintNFTForBook(book, callbacks)
 
       // Step 4: Create book listing
       onStatusChange?.(book.id, BookUploadStatus.LISTING)
@@ -247,6 +247,21 @@ export function useBulkUpload() {
       throw new Error('Class ID not found')
     }
 
+    const setMintTxHash = (hash: string | undefined) => {
+      book.mintTxHash = hash
+      onProgress?.(book.id, { mintTxHash: hash })
+    }
+
+    // A prior attempt may have broadcast a mint whose confirmation we never
+    // recorded; re-minting reuses the same fromTokenId and would revert against
+    // the already-minted token, so verify any persisted hash before re-minting.
+    if (book.mintTxHash) {
+      if (await isMintTransactionConfirmed(book.mintTxHash)) {
+        return
+      }
+      setMintTxHash(undefined)
+    }
+
     const mintCount = NFT_DEFAULT_MINT_AMOUNT
 
     const buildTokenMetadata = (index: number, fromTokenId: bigint): NFTTokenMetadata => ({
@@ -260,14 +275,26 @@ export function useBulkUpload() {
       ],
     })
 
-    const { txHash } = await mintNFT({
+    // onSubmitted persists the hash as soon as the mint is broadcast, before the
+    // confirmation wait — so an interruption there can't trigger a duplicate mint.
+    await mintNFT({
       classId: book.classId,
       mintCount,
       buildTokenMetadata,
+      onSubmitted: setMintTxHash,
     })
+  }
 
-    book.mintTxHash = txHash
-    onProgress?.(book.id, { mintTxHash: txHash })
+  // Returns true only for a confirmed-successful receipt and false for a
+  // confirmed-reverted one. Receipt lookup throws while the tx is still pending
+  // (TransactionReceiptNotFoundError) or on a transient RPC error — we let that
+  // propagate so callers treat "unknown" as pending and keep the hash, rather
+  // than clearing it and risking a duplicate re-mint.
+  async function isMintTransactionConfirmed(txHash: string): Promise<boolean> {
+    const receipt = await getTransactionReceipt($wagmiConfig, {
+      hash: txHash as `0x${string}`,
+    })
+    return receipt?.status === 'success'
   }
 
   async function createBookListing(
@@ -364,5 +391,6 @@ export function useBulkUpload() {
     currentStep: readonly(currentStep),
     processBook,
     processBooksSequentially,
+    isMintTransactionConfirmed,
   }
 }

--- a/app/composables/useContractWrite.ts
+++ b/app/composables/useContractWrite.ts
@@ -1,7 +1,7 @@
 import { useWriteContract } from '@wagmi/vue'
 import type { Hash } from 'viem'
 
-import type { SponsoredWriteContractParams } from './useSponsoredTransaction'
+import { SponsoredTransactionBroadcastError, type SponsoredWriteContractParams } from './useSponsoredTransaction'
 
 export function useContractWrite() {
   const { writeContractAsync: wagmiWriteContract } = useWriteContract()
@@ -15,6 +15,12 @@ export function useContractWrite() {
         return await sponsoredWriteContract(params)
       }
       catch (error) {
+        // If the sponsored transaction was already broadcast, retrying it as a
+        // direct transaction would double-execute the call. Surface the error
+        // instead of falling back.
+        if (error instanceof SponsoredTransactionBroadcastError) {
+          throw error
+        }
         console.warn('[Sponsored TX] Failed, falling back to direct transaction:', error)
       }
     }

--- a/app/composables/useNFTMinter.ts
+++ b/app/composables/useNFTMinter.ts
@@ -19,8 +19,12 @@ export function useNFTMinter() {
     classId: string
     mintCount: number
     buildTokenMetadata: (index: number, fromTokenId: bigint) => NFTTokenMetadata
+    // Called as soon as the mint tx is broadcast, before waiting for the
+    // receipt. Lets callers persist the hash so an interrupted confirmation
+    // wait doesn't lead to a duplicate mint on retry.
+    onSubmitted?: (txHash: string) => void
   }): Promise<{ txHash: string, fromTokenId: bigint }> {
-    const { classId, mintCount, buildTokenMetadata } = params
+    const { classId, mintCount, buildTokenMetadata, onSubmitted } = params
 
     await checkAndGrantMinter({
       classId,
@@ -51,6 +55,7 @@ export function useNFTMinter() {
     })
 
     const txHash = await writeContractAsync(txParams)
+    onSubmitted?.(txHash)
     const receipt = await waitForTransactionReceipt({ hash: txHash, confirmations: 2 })
 
     if (!receipt || receipt.status !== 'success') {

--- a/app/composables/useSponsoredTransaction.ts
+++ b/app/composables/useSponsoredTransaction.ts
@@ -10,6 +10,23 @@ export interface SponsoredWriteContractParams {
   args?: readonly unknown[]
 }
 
+/**
+ * Thrown when a sponsored transaction has already been broadcast (sendCalls
+ * resolved) but we failed to read back its status/receipt. The transaction may
+ * well have executed on-chain, so the caller MUST NOT retry it via a direct
+ * transaction — doing so double-executes the call (e.g. a second mint of an
+ * already-minted tokenId, which reverts).
+ */
+export class SponsoredTransactionBroadcastError extends Error {
+  callsId?: string
+  constructor(message: string, options?: { cause?: unknown, callsId?: string }) {
+    super(message)
+    this.name = 'SponsoredTransactionBroadcastError'
+    this.cause = options?.cause
+    this.callsId = options?.callsId
+  }
+}
+
 let alchemyModules: Awaited<ReturnType<typeof loadAlchemyModules>> | null = null
 let cachedSmartWalletClient: any | null = null
 let cachedMagicInstance: Magic | null = null
@@ -126,9 +143,12 @@ export function useSponsoredTransaction() {
       throw new Error('No connected account')
     }
 
-    let txHash: Hash | undefined
+    // Pre-broadcast phase: failures here mean nothing was submitted, so the
+    // caller is free to fall back to a direct transaction.
+    let client: any
+    let result: { id: string }
     try {
-      const client = await getOrCreateSmartWalletClient()
+      client = await getOrCreateSmartWalletClient()
 
       const callData = encodeFunctionData({
         abi: params.abi as Abi,
@@ -136,7 +156,7 @@ export function useSponsoredTransaction() {
         args: params.args || [],
       })
 
-      const result = await client.sendCalls({
+      result = await client.sendCalls({
         from: address.value,
         calls: [{
           to: params.address,
@@ -147,19 +167,29 @@ export function useSponsoredTransaction() {
           eip7702Auth: true,
         },
       })
-
-      const status = await client.waitForCallsStatus({ id: result.id })
-      txHash = status.receipts?.[0]?.transactionHash as Hash | undefined
     }
     catch (error) {
       clearSponsoredClientCache()
       throw error
     }
 
-    if (!txHash) {
-      throw new Error('Sponsored transaction failed: no receipt returned')
+    // Post-broadcast phase: the calls have been submitted. If we can't confirm
+    // the status, surface a dedicated error so the caller does NOT re-submit.
+    try {
+      const status = await client.waitForCallsStatus({ id: result.id })
+      const txHash = status.receipts?.[0]?.transactionHash as Hash | undefined
+      if (!txHash) {
+        throw new Error('no receipt returned')
+      }
+      return txHash
     }
-    return txHash
+    catch (error) {
+      clearSponsoredClientCache()
+      throw new SponsoredTransactionBroadcastError(
+        'Sponsored transaction was broadcast but its status could not be confirmed',
+        { cause: error, callsId: result.id },
+      )
+    }
   }
 
   watch(isSponsoredMode, (newVal) => {

--- a/app/pages/bulk-upload.vue
+++ b/app/pages/bulk-upload.vue
@@ -454,7 +454,6 @@
 <script setup lang="ts">
 import { parse as csvParse } from 'csv-parse/sync'
 import { stringify as csvStringify } from 'csv-stringify/sync'
-import { getTransactionReceipt } from '@wagmi/vue/actions'
 import { estimateBundlrFilePrice, canSponsorArweaveUpload } from '~/utils/arweave'
 import type { ArweaveEstimate } from '~/types'
 import type { BulkUploadBook, BulkUploadCSVRow, BulkUploadValidationError } from '~/types/bulk-upload'
@@ -471,9 +470,8 @@ const { t: $t } = useI18n()
 const toast = useToast()
 const bookstoreApiStore = useBookstoreApiStore()
 const { token } = storeToRefs(bookstoreApiStore)
-const { processBooksSequentially, currentStep: currentProcessingStep, currentBook: currentProcessingBook } = useBulkUpload()
+const { processBooksSequentially, isMintTransactionConfirmed, currentStep: currentProcessingStep, currentBook: currentProcessingBook } = useBulkUpload()
 const { getClassMetadata } = useNFTContractReader()
-const { $wagmiConfig } = useNuxtApp()
 
 // State
 const currentStep = ref<'csv' | 'files' | 'review' | 'processing'>('csv')
@@ -748,10 +746,13 @@ async function verifyProgressFieldsOnChain(booksToVerify: BulkUploadBook[]) {
 
     if (book.mintTxHash) {
       try {
-        await getTransactionReceipt($wagmiConfig, { hash: book.mintTxHash as `0x${string}` })
+        if (!(await isMintTransactionConfirmed(book.mintTxHash))) {
+          book.mintTxHash = undefined
+        }
       }
       catch {
-        book.mintTxHash = undefined
+        // Receipt not available yet (pending tx / transient RPC issue) — keep
+        // the hash so resume verification can't trigger a duplicate mint.
       }
     }
   }


### PR DESCRIPTION
A sponsored mint that broadcasts but fails its status read was retried as a direct transaction, re-minting the already-created tokenId and reverting. Likewise, a successful mint whose receipt wait threw lost its txHash and was re-minted on retry/resume.

- Split sponsoredWriteContract into pre- and post-broadcast phases; throw a dedicated SponsoredTransactionBroadcastError once broadcast so the caller no longer falls back to a direct (duplicate) transaction.
- Persist mintTxHash as soon as the mint is broadcast (onSubmitted), and make the mint step idempotent by verifying any persisted hash on-chain before re-minting.
- Reuse the shared receipt check in verifyProgressFieldsOnChain so reverted txs are also treated as not-minted.