### PR TITLE
🐛 Fix wallet connect crash from reactive connector proxy

### DIFF
--- a/app/stores/wallet.ts
+++ b/app/stores/wallet.ts
@@ -82,7 +82,11 @@ export const useWalletStore = defineStore('wallet', () => {
         (c: { id: string }) => c.id === connectorId,
       )
       if (!connector) { return }
-      await wagmiConnect({ connector, chainId })
+      // `connectors` is a Vue reactive array, so unwrap the proxy before
+      // handing it to wagmi core: its cycle-detection-free `deepEqual` would
+      // otherwise recurse through the proxy's circular connector→config graph
+      // and throw "Maximum call stack size exceeded".
+      await wagmiConnect({ connector: toRaw(connector), chainId })
 
       isLoginLoading.value = true
 


### PR DESCRIPTION
`connectors` from `useConnect()` is a Vue reactive array, so the connector passed to wagmi core was a proxy. Wagmi's cycle-detection-free `deepEqual` recursed through its circular connector→config graph and threw "Maximum call stack size exceeded" on connect. Unwrap with `toRaw()` before handing the connector to core.