### PR TITLE
💬 Note Plus TTS engagement counts only borrowed reads

### DIFF
--- a/app/pages/my-books/status/[classId].vue
+++ b/app/pages/my-books/status/[classId].vue
@@ -688,9 +688,9 @@ const isPlusReadingEnabledRadio = computed({
   set: (val: string) => { isPlusReadingEnabled.value = val === 'join' },
 })
 
-// Live Plus reading-library engagement for this book (current, not-yet-settled usage). Reading
-// time counts only borrowed (Plus-library) reads; listening (TTS) counts any read by a paid
-// Plus member — so these are rev-share-eligible durations, not gross engagement.
+// Live Plus reading-library engagement for this book (current, not-yet-settled usage). Both
+// reading time and listening (TTS) count only borrowed (Plus-library) reads by a paid Plus
+// member — so these are rev-share-eligible durations, not gross engagement.
 const plusReadingStats = ref<PlusReadingStats['stats']>([])
 const plusReadingStatsSummary = ref<PlusReadingStats['summary']>({
   totalReadingTimeMs: 0,

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -711,7 +711,7 @@
   "plus_reading_report.summary_total": "Total Earnings",
   "plus_reading_report.title": "Plus Reading Library Earnings",
   "plus_reading_report.tts_rate": "Listening Rate (USD/min)",
-  "plus_reading_stats.description": "Live Plus reading-library engagement for this book (current, not-yet-settled). Reading counts borrowed reads; listening counts any read by a paid Plus member.",
+  "plus_reading_stats.description": "Live Plus reading-library engagement for this book (current, not-yet-settled). Reading and listening both count only borrowed reads by a paid Plus member.",
   "plus_reading_stats.listening_minutes": "Listening (min)",
   "plus_reading_stats.period": "Period",
   "plus_reading_stats.reading_minutes": "Reading (min)",

--- a/i18n/locales/zh-TW.json
+++ b/i18n/locales/zh-TW.json
@@ -711,7 +711,7 @@
   "plus_reading_report.summary_total": "總收益",
   "plus_reading_report.title": "Plus 圖書館閱覽分成報表",
   "plus_reading_report.tts_rate": "朗讀單價（USD/分鐘）",
-  "plus_reading_stats.description": "此書即時的 Plus 圖書館閱覽數據（當期、尚未結算）。閱讀時間只計入借閱，朗讀時間計入付費 Plus 會員的任何閱讀。",
+  "plus_reading_stats.description": "此書即時的 Plus 圖書館閱覽數據（當期、尚未結算）。閱讀與朗讀時間均只計入付費 Plus 會員的借閱。",
   "plus_reading_stats.listening_minutes": "朗讀時間（分鐘）",
   "plus_reading_stats.period": "期間",
   "plus_reading_stats.reading_minutes": "閱讀時間（分鐘）",


### PR DESCRIPTION
Reflect the rev-share rule change: listening (TTS) now counts only borrowed Plus-library reads, not any read by a paid Plus member.