### PR TITLE
[TAS-6108] 💄 Widen genre select and add reset option

### DIFF
--- a/app/components/ISCNForm.vue
+++ b/app/components/ISCNForm.vue
@@ -83,9 +83,10 @@
 
       <UFormField :label="$t('form.genre')">
         <USelect
-          v-model="formData.genre"
+          v-model="genreModel"
           :items="bookCategoryOptions"
           :placeholder="$t('iscn_form.select_genre')"
+          :ui="{ content: 'w-fit min-w-(--reka-select-trigger-width)' }"
         />
       </UFormField>
 
@@ -376,10 +377,16 @@ const downloadTypeOptions = [
   { label: 'Other', value: 'other' },
 ]
 
-const bookCategoryOptions = BOOK_CATEGORIES.map(cat => ({
-  label: $t(cat.i18nKey),
-  value: cat.value as string,
-}))
+// Reka UI's SelectItem rejects an empty-string value (it is reserved for the
+// cleared state), so the reset option uses a sentinel mapped back to '' below.
+const GENRE_NONE_VALUE = '__none__'
+const bookCategoryOptions = [
+  { label: $t('iscn_form.genre_none'), value: GENRE_NONE_VALUE },
+  ...BOOK_CATEGORIES.map(cat => ({
+    label: $t(cat.i18nKey),
+    value: cat.value as string,
+  })),
+]
 
 const shouldShowUploadModal = ref(false)
 const uploadFormRef = ref()
@@ -387,6 +394,14 @@ const fileRecords = ref<FileRecord[]>([])
 const uploadStatus = ref('')
 
 const formData = defineModel<ISCNFormData>({ required: true })
+
+// Bridge the empty stored genre to the dropdown's non-empty sentinel option.
+const genreModel = computed({
+  get: () => formData.value.genre || GENRE_NONE_VALUE,
+  set: (value: string) => {
+    formData.value.genre = value === GENRE_NONE_VALUE ? '' : value
+  },
+})
 
 const initialFormDataSnapshot = ref<string>('')
 

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -430,6 +430,7 @@
   "iscn_form.publisher_description": "Publisher Description",
   "iscn_form.select_date": "Select date",
   "iscn_form.select_file_type": "Select file type",
+  "iscn_form.genre_none": "Unspecified",
   "iscn_form.select_genre": "Select category",
   "iscn_form.select_language": "Select language",
   "iscn_form.select_license": "Select license",

--- a/i18n/locales/zh-TW.json
+++ b/i18n/locales/zh-TW.json
@@ -430,6 +430,7 @@
   "iscn_form.publisher_description": "出版社描述",
   "iscn_form.select_date": "選擇日期",
   "iscn_form.select_file_type": "選擇檔案類型",
+  "iscn_form.genre_none": "不指定",
   "iscn_form.select_genre": "選擇分類",
   "iscn_form.select_language": "選擇語言",
   "iscn_form.select_license": "選擇授權",


### PR DESCRIPTION

<img width="240" height="330" alt="image" src="https://github.com/user-attachments/assets/39eab62f-6ff0-4e03-9b5d-30b22c74b377" />


Override the genre dropdown content width so long category labels are no longer truncated, and prepend a blank "unspecified" option so users can clear a previously chosen category.