### PR TITLE
🐛 Fix readonly-set warning on wallet isConnected

### DIFF
--- a/app/stores/wallet.ts
+++ b/app/stores/wallet.ts
@@ -24,6 +24,9 @@ export const useWalletStore = defineStore('wallet', () => {
   const isLoginLoading = ref(false)
 
   const wallet = computed(() => address.value ? checksumAddress(address.value) : undefined)
+  // Wrap wagmi's readonly `isConnected` ref in a computed so Pinia treats it as a
+  // getter, not writable state, avoiding a readonly-set warning on SSR hydration.
+  const isWalletConnected = computed(() => isConnected.value)
 
   const getLikeCoinV3BookMigrationSiteURL = computed(() => ({ utmSource }: { utmSource?: string } = {}) => {
     const { locale } = useI18n()
@@ -436,7 +439,7 @@ export const useWalletStore = defineStore('wallet', () => {
   return {
     wallet,
     signer: ref({}),
-    isConnected,
+    isConnected: isWalletConnected,
     isLoginLoading,
     initIfNecessary,
     validateWalletConsistency,


### PR DESCRIPTION
Wagmi's `useConnection` returns readonly refs. Returning `isConnected` raw made Pinia treat it as writable state and attempt a set on SSR hydration, triggering a Vue readonly warning. Wrap it in a computed so Pinia treats it as a getter, mirroring how `wallet` is exposed.