### PR TITLE
🐛 Surface real error when sponsored tx fails on unfunded wallet

### DIFF
--- a/app/composables/useContractWrite.ts
+++ b/app/composables/useContractWrite.ts
@@ -1,5 +1,5 @@
-import { useWriteContract } from '@wagmi/vue'
-import type { Hash } from 'viem'
+import { useConnection, useWriteContract } from '@wagmi/vue'
+import { encodeFunctionData, type Abi, type Hash } from 'viem'
 
 import { SponsoredTransactionBroadcastError, type SponsoredWriteContractParams } from './useSponsoredTransaction'
 
@@ -7,6 +7,8 @@ export function useContractWrite() {
   const { writeContractAsync: wagmiWriteContract } = useWriteContract()
   const { ensureMagicSession } = useMagicSession()
   const { isSponsoredMode, sponsoredWriteContract } = useSponsoredTransaction()
+  const { hasSufficientBalanceForTx } = useGasBalanceCheck()
+  const { address } = useConnection()
 
   async function writeContractAsync(params: SponsoredWriteContractParams): Promise<Hash> {
     await ensureMagicSession()
@@ -21,7 +23,25 @@ export function useContractWrite() {
         if (error instanceof SponsoredTransactionBroadcastError) {
           throw error
         }
-        console.warn('[Sponsored TX] Failed, falling back to direct transaction:', error)
+        // Sponsored mode users (Magic) usually hold no gas, so falling back to a
+        // direct transaction would fail with a misleading "insufficient funds"
+        // that buries the real cause (e.g. per-address gas policy limit). Only
+        // fall back when the wallet can actually pay its own gas; otherwise
+        // surface the original sponsorship error.
+        const callData = encodeFunctionData({
+          abi: params.abi as Abi,
+          functionName: params.functionName,
+          args: params.args || [],
+        })
+        const canSelfPay = !!address.value
+          && await hasSufficientBalanceForTx({
+            wallet: address.value,
+            tx: { to: params.address, data: callData, value: 0n },
+          })
+        if (!canSelfPay) {
+          throw error
+        }
+        console.warn('[Sponsored TX] Failed but wallet is funded, falling back to direct transaction:', error)
       }
     }
     return wagmiWriteContract(params as Parameters<typeof wagmiWriteContract>[0])

--- a/app/composables/useGasBalanceCheck.ts
+++ b/app/composables/useGasBalanceCheck.ts
@@ -1,0 +1,100 @@
+import { getBalance, estimateGas, getGasPrice } from '@wagmi/vue/actions'
+import { formatEther } from 'viem'
+import type { EstimateGasParameters } from 'viem'
+
+// Used only when on-chain estimateGas fails, so the check can still proceed.
+const GAS_LIMIT_CONTRACT_CALL = 1_500_000n
+const GAS_LIMIT_PLAIN_TRANSFER = 21_000n
+const GAS_LIMIT_FALLBACK = 500_000n
+
+interface GasCheckParams {
+  wallet: string
+  tx: EstimateGasParameters
+  value?: bigint
+}
+
+export const useGasBalanceCheck = () => {
+  const { $wagmiConfig: config } = useNuxtApp()
+  const { t: $t } = useI18n()
+  const toast = useToast()
+
+  const showGasFeeError = (walletAddress: string, currentBalance: bigint, neededBalance: bigint) => {
+    const currentBalanceFormatted = formatEther(currentBalance)
+    const neededBalanceFormatted = formatEther(neededBalance)
+    toast.add({
+      icon: 'i-heroicons-exclamation-circle',
+      title: $t('errors.insufficient_gas_fee'),
+      description: $t('errors.insufficient_gas_fee_description', {
+        currentBalance: currentBalanceFormatted,
+        neededBalance: neededBalanceFormatted,
+      }),
+      duration: 0,
+      color: 'warning',
+      actions: [
+        {
+          label: $t('errors.contact_support'),
+          onClick: () => {
+            if (window.Intercom) {
+              window.Intercom('showNewMessage', $t('errors.insufficient_gas_fee_support_message', {
+                walletAddress,
+                currentBalance: currentBalanceFormatted,
+                neededBalance: neededBalanceFormatted,
+              }))
+            }
+          },
+        },
+      ],
+    })
+  }
+
+  const evaluateBalanceForTx = async ({ wallet, tx, value }: GasCheckParams) => {
+    const hasData = 'data' in tx && (tx as { data?: `0x${string}` | undefined }).data != null
+    let defaultGasLimit = GAS_LIMIT_FALLBACK
+    if (hasData) defaultGasLimit = GAS_LIMIT_CONTRACT_CALL
+    else if ('to' in tx) defaultGasLimit = GAS_LIMIT_PLAIN_TRANSFER
+
+    const [balanceResult, gasEstimateResult, gasPriceResult] = await Promise.allSettled([
+      getBalance(config, { address: wallet as `0x${string}` }),
+      estimateGas(config, { ...tx, account: wallet as `0x${string}` }),
+      getGasPrice(config),
+    ])
+
+    const balance = balanceResult.status === 'fulfilled' ? balanceResult.value : { value: 0n }
+    const gasEstimate = gasEstimateResult.status === 'fulfilled' ? gasEstimateResult.value : defaultGasLimit
+    const estimatedGasPrice = gasPriceResult.status === 'fulfilled' ? gasPriceResult.value : 1000000000n // 1 gwei fallback for Base
+
+    const estimatedGasCost = gasEstimate * estimatedGasPrice
+    // Add a 20% safety buffer to the estimated gas cost to account for gas price volatility
+    // and potential differences between estimation time and actual transaction execution.
+    const requiredBalance = (estimatedGasCost * 120n) / 100n
+    // Fall back to tx.value so a caller that sets the transfer amount only on
+    // the tx (for estimateGas) doesn't under-count the required balance.
+    const txValue = ('value' in tx ? (tx as { value?: bigint }).value : undefined) ?? 0n
+    const totalRequired = requiredBalance + (value ?? txValue)
+
+    return {
+      balance,
+      totalRequired,
+      hasSufficient: balance.value >= totalRequired,
+    }
+  }
+
+  const hasSufficientBalanceForTx = async (params: GasCheckParams) => {
+    const { hasSufficient } = await evaluateBalanceForTx(params)
+    return hasSufficient
+  }
+
+  const assertSufficientBalanceForTx = async (params: GasCheckParams) => {
+    const { balance, totalRequired, hasSufficient } = await evaluateBalanceForTx(params)
+    if (!hasSufficient) {
+      showGasFeeError(params.wallet, balance.value, totalRequired)
+      throw new Error('INSUFFICIENT_GAS_FEE_BALANCE')
+    }
+  }
+
+  return {
+    showGasFeeError,
+    hasSufficientBalanceForTx,
+    assertSufficientBalanceForTx,
+  }
+}

--- a/app/composables/useNFTContractWriter.ts
+++ b/app/composables/useNFTContractWriter.ts
@@ -1,43 +1,13 @@
-import { readContract, getBalance, waitForTransactionReceipt as wagmiWaitForTransactionReceipt, estimateGas, getGasPrice } from '@wagmi/vue/actions'
-import { encodeFunctionData, formatEther } from 'viem'
-import type { Abi, EstimateGasParameters } from 'viem'
+import { readContract, waitForTransactionReceipt as wagmiWaitForTransactionReceipt } from '@wagmi/vue/actions'
+import { encodeFunctionData } from 'viem'
+import type { Abi } from 'viem'
 import { LIKE_NFT_CLASS_ABI } from '~/contracts/likeNFT'
 import { sleep } from '~/utils'
 
 export const useNFTContractWriter = () => {
   const { writeContractAsync, isSponsoredMode } = useContractWrite()
   const { $wagmiConfig: config } = useNuxtApp()
-  const { t: $t } = useI18n()
-  const toast = useToast()
-
-  const showGasFeeError = (walletAddress: string, currentBalance: bigint, neededBalance: bigint) => {
-    const currentBalanceFormatted = formatEther(currentBalance)
-    const neededBalanceFormatted = formatEther(neededBalance)
-    toast.add({
-      icon: 'i-heroicons-exclamation-circle',
-      title: $t('errors.insufficient_gas_fee'),
-      description: $t('errors.insufficient_gas_fee_description', {
-        currentBalance: currentBalanceFormatted,
-        neededBalance: neededBalanceFormatted,
-      }),
-      duration: 0,
-      color: 'warning',
-      actions: [
-        {
-          label: $t('errors.contact_support'),
-          onClick: () => {
-            if (window.Intercom) {
-              window.Intercom('showNewMessage', $t('errors.insufficient_gas_fee_support_message', {
-                walletAddress,
-                currentBalance: currentBalanceFormatted,
-                neededBalance: neededBalanceFormatted,
-              }))
-            }
-          },
-        },
-      ],
-    })
-  }
+  const { assertSufficientBalanceForTx } = useGasBalanceCheck()
 
   const checkAndGrantRole = async (
     { classId, wallet }: { classId: string, wallet: string },
@@ -130,40 +100,6 @@ export const useNFTContractWriter = () => {
       tx: { to: params.to, value: params.value, data: params.data },
       value: params.value,
     })
-  }
-
-  const assertSufficientBalanceForTx = async (params: {
-    wallet: string
-    tx: EstimateGasParameters
-    value?: bigint
-  }) => {
-    const { wallet, tx, value } = params
-    const hasTo = 'to' in tx
-    const hasData = 'data' in tx && (tx as { data?: `0x${string}` | undefined }).data != null
-    const defaultGasLimit = hasData ? 1_500_000n : hasTo ? 21000n : 500000n
-
-    const [balanceResult, gasEstimateResult, gasPriceResult] = await Promise.allSettled([
-      getBalance(config, { address: wallet as `0x${string}` }),
-      estimateGas(config, { ...tx, account: wallet as `0x${string}` }),
-      getGasPrice(config),
-    ])
-
-    const balance = balanceResult.status === 'fulfilled' ? balanceResult.value : { value: 0n }
-    const gasEstimate = gasEstimateResult.status === 'fulfilled' ? gasEstimateResult.value : defaultGasLimit
-    const estimatedGasPrice = gasPriceResult.status === 'fulfilled' ? gasPriceResult.value : 1000000000n // 1 gwei fallback for Base
-
-    const estimatedGasCost = gasEstimate * estimatedGasPrice
-    // Add a 20% safety buffer to the estimated gas cost to account for gas price volatility
-    // and potential differences between estimation time and actual transaction execution.
-    const requiredBalance = (estimatedGasCost * 120n) / 100n
-    const totalRequired = requiredBalance + (value ?? 0n)
-
-    if (balance.value < totalRequired) {
-      showGasFeeError(wallet, balance.value, totalRequired)
-      throw new Error('INSUFFICIENT_GAS_FEE_BALANCE')
-    }
-
-    return { balance, gasEstimate, estimatedGasCost, requiredBalance }
   }
 
   return {


### PR DESCRIPTION
When a sponsored (Magic) transaction was rejected pre-broadcast (e.g. the Alchemy gas policy hit its per-address cost limit), the code silently fell back to a direct EOA transaction. Magic wallets hold no gas, so that fallback failed with a misleading "insufficient funds" that buried the real cause.

The fallback is now balance-aware: it only falls back to a direct transaction when the wallet can actually pay its own gas, otherwise it re-throws the original sponsorship error.

Extracts the gas balance-check logic out of useNFTContractWriter into a shared useGasBalanceCheck composable (avoiding a circular import) and adds a side-effect-free hasSufficientBalanceForTx used to make the fallback decision.