### PR TITLE
♻️ Move descriptionFull from on-chain metadata to store listing

### DIFF
--- a/app/components/EditISCNMetadataForm.vue
+++ b/app/components/EditISCNMetadataForm.vue
@@ -10,6 +10,7 @@
       v-else
       ref="iscnFormRef"
       v-model="iscnFormData"
+      :show-description-full="false"
     />
     <div class="w-full flex justify-center items-center gap-2 my-4">
       <UButton

--- a/app/components/EditISCNMetadataModal.vue
+++ b/app/components/EditISCNMetadataModal.vue
@@ -27,6 +27,7 @@
         v-else
         ref="iscnFormRef"
         v-model="iscnFormData"
+        :show-description-full="false"
       />
     </template>
     <template #footer>

--- a/app/components/ISCNForm.vue
+++ b/app/components/ISCNForm.vue
@@ -39,11 +39,13 @@
     </UFormField>
 
     <ToggleTextarea
+      v-if="showDescriptionFull"
       v-model="formData.descriptionFull"
       :label="$t('iscn_form.description_full')"
       :toggle-label="$t('iscn_form.enable_description_full')"
       :placeholder="$t('iscn_form.enter_iscn_description_full', { maxLength: MAX_DESCRIPTION_FULL_LENGTH })"
       :max-length="MAX_DESCRIPTION_FULL_LENGTH"
+      :force-open="isDescriptionOverMax"
     />
 
     <div class="grid grid-cols-3 gap-4">
@@ -384,6 +386,13 @@ const uploadFormRef = ref()
 const fileRecords = ref<FileRecord[]>([])
 const uploadStatus = ref('')
 
+// descriptionFull now lives in the store listing, not on-chain metadata. Edit
+// surfaces hide it here and edit it via listing settings instead; the new-book
+// flow keeps showing it and bridges the value to listing creation.
+withDefaults(defineProps<{ showDescriptionFull?: boolean }>(), {
+  showDescriptionFull: true,
+})
+
 const formData = defineModel<ISCNFormData>({ required: true })
 
 // Bridge the empty stored genre to the dropdown's non-empty sentinel option.
@@ -448,12 +457,15 @@ const shouldDisableAction = computed(() => {
   return uploadStatus.value !== ''
 })
 
+const isDescriptionOverMax = computed(() => {
+  return (formData.value.description || '').length > MAX_DESCRIPTION_LENGTH
+})
+
 const descriptionError = computed(() => {
-  const desc = formData.value.description || ''
-  if (!desc) {
-    return 'Description is required'
+  if (!formData.value.description) {
+    return $t('iscn_form.description_required')
   }
-  else if (desc.length > MAX_DESCRIPTION_LENGTH) {
+  else if (isDescriptionOverMax.value) {
     return $t('validation.description_cannot_exceed', { max: MAX_DESCRIPTION_LENGTH })
   }
   return false

--- a/app/components/NewNFTBook.vue
+++ b/app/components/NewNFTBook.vue
@@ -469,7 +469,7 @@ import {
   MINIMAL_PRICE,
 } from '~/constant'
 import { getApiEndpoints } from '~/constant/api'
-import { getUploadFileData } from '~/utils/uploadFile'
+import { getUploadFileData, getPendingDescriptionFull } from '~/utils/uploadFile'
 import type { BookPriceInDecimalByCurrency, ClassListingData, ClassListingPrice } from '~/types'
 
 const { t: $t } = useI18n()
@@ -1027,6 +1027,10 @@ async function submitNewClass() {
       isAdultOnly: isAdultOnly.value,
       isPlusReadingEnabled: isPlusReadingEnabled.value,
       tableOfContents: tableOfContents.value || undefined,
+      // Not on-chain anymore; read the ISCN-step value from the bridge (wizard
+      // only). The non-wizard "create missing listing" path must not pick up a
+      // stale value left over from an abandoned new-book session in this tab.
+      descriptionFull: (props.isNewClassPage && getPendingDescriptionFull()) || undefined,
     })
   }
   catch (err) {

--- a/app/components/RegisterISCN.vue
+++ b/app/components/RegisterISCN.vue
@@ -87,6 +87,16 @@ onMounted(() => {
   if (initialData) {
     iscnFormData.value = initialData
   }
+  // descriptionFull is no longer written on-chain; carry the author's input via
+  // the bridge so it survives navigation to mint and lands on listing creation.
+  const pendingDescriptionFull = getPendingDescriptionFull()
+  if (pendingDescriptionFull) {
+    iscnFormData.value.descriptionFull = pendingDescriptionFull
+  }
+})
+
+watch(() => iscnFormData.value.descriptionFull, (value) => {
+  setPendingDescriptionFull(value || '')
 })
 
 const initializeFromSessionStorage = () => {

--- a/app/components/ToggleTextarea.vue
+++ b/app/components/ToggleTextarea.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col gap-2">
+  <div class="flex flex-col gap-2 text-left">
     <UCheckbox
       :model-value="isOpen"
       :label="toggleLabel"
@@ -28,16 +28,25 @@ const props = defineProps<{
   toggleLabel: string
   placeholder: string
   maxLength: number
+  forceOpen?: boolean
 }>()
 
 const modelValue = defineModel<string>()
 
 const { t: $t } = useI18n()
 
-const isOpen = ref(!!modelValue.value)
+const isOpen = ref(!!modelValue.value || !!props.forceOpen)
 
 watch(modelValue, (val, oldVal) => {
   if (val && !oldVal && !isOpen.value) {
+    isOpen.value = true
+  }
+})
+
+// Auto-expand when the parent signals the field is required (e.g. the main
+// description exceeds its limit and the overflow belongs in the full description).
+watch(() => props.forceOpen, (val) => {
+  if (val) {
     isOpen.value = true
   }
 })

--- a/app/composables/useBulkUpload.ts
+++ b/app/composables/useBulkUpload.ts
@@ -204,7 +204,6 @@ export function useBulkUpload() {
       type: 'Book',
       title: book.title,
       description: book.description,
-      descriptionFull: book.descriptionFull?.trim() || undefined,
       alternativeHeadline: '',
       isbn: book.isbn || '',
       publisher: {
@@ -343,6 +342,7 @@ export function useBulkUpload() {
       hideDownload: book.enableDRM,
       hideAudio: !book.enableTTS,
       isPlusReadingEnabled: book.isPlusReadingEnabled,
+      descriptionFull: book.descriptionFull?.trim() || undefined,
     })
   }
 

--- a/app/composables/useISCN.ts
+++ b/app/composables/useISCN.ts
@@ -84,7 +84,6 @@ export function useISCN({
     '@type': iscnFormData.value.type,
     'name': iscnFormData.value.title,
     'description': iscnFormData.value.description,
-    'descriptionFull': iscnFormData.value.descriptionFull || undefined,
     'alternativeHeadline': iscnFormData.value.alternativeHeadline || undefined,
     'author': iscnFormData.value.author.name,
     'authorDescription': iscnFormData.value.author.description,
@@ -106,8 +105,10 @@ export function useISCN({
     'tagsString': iscnFormData.value.tags?.join(', ') || '',
     'thumbnailUrl': iscnFormData.value.coverUrl,
     'genre': iscnFormData.value.genre || undefined,
-    // Actively remove legacy preview content (hasPart) from existing metadata
-    // on update. Spreading existingIscnData would otherwise re-inject it.
+    // Actively remove legacy fields from existing metadata on update; they now
+    // live in the store listing (descriptionFull) or are deprecated (hasPart).
+    // Spreading existingIscnData would otherwise re-inject them.
+    'descriptionFull': undefined,
     'hasPart': undefined,
     'potentialAction': formattedPotentialActionList.value,
     'attributes': getAttributes(iscnFormData.value),

--- a/app/pages/my-books/status/[classId].vue
+++ b/app/pages/my-books/status/[classId].vue
@@ -563,6 +563,14 @@
               />
             </UFormField>
 
+            <ToggleTextarea
+              v-model="descriptionFull"
+              :label="$t('iscn_form.description_full')"
+              :toggle-label="$t('iscn_form.enable_description_full')"
+              :placeholder="$t('iscn_form.enter_iscn_description_full', { maxLength: MAX_DESCRIPTION_FULL_LENGTH })"
+              :max-length="MAX_DESCRIPTION_FULL_LENGTH"
+            />
+
             <UFormField :label="$t('form.table_of_content')">
               <UTextarea
                 v-model="tableOfContents"
@@ -619,6 +627,7 @@ import { whenever } from '@vueuse/core'
 import { getPortfolioURL, downloadFile, convertArrayOfObjectsToCSV, getPurchaseLink, copyToClipboard, convertMsToMinutes } from '~/utils'
 import type { PurchaseItem, ClassListingData, ClassListingPrice, EditionTableRow, PlusReadingStats } from '~/types'
 import { getApiEndpoints } from '~/constant/api'
+import { MAX_DESCRIPTION_FULL_LENGTH } from '~/constant/index'
 
 const { t: $t } = useI18n()
 
@@ -659,6 +668,7 @@ const showEditISCN = ref(false)
 const searchInput = ref('')
 
 const tableOfContents = ref('')
+const descriptionFull = ref<string | undefined>('')
 
 const moderatorWallets = ref<string[]>([])
 const moderatorWalletInput = ref('')
@@ -1096,6 +1106,7 @@ onMounted(async () => {
       connectedWallets: classConnectedWallets,
       mustClaimToView: classMustClaimToView,
       tableOfContents: classTableOfContent,
+      descriptionFull: classDescriptionFull,
       enableCustomMessagePage: classEnableCustomMessagePage,
       hideDownload: classHideDownload,
       hideAudio: classHideAudio,
@@ -1128,6 +1139,7 @@ onMounted(async () => {
     isPlusReadingEnabled.value = isFreeBook.value || (classIsPlusReadingEnabled ?? false)
     enableCustomMessagePage.value = classEnableCustomMessagePage ?? true
     tableOfContents.value = classTableOfContent ?? ''
+    descriptionFull.value = classDescriptionFull ?? ''
     // Independent fetches — run concurrently to keep them off each other's critical path.
     await Promise.all([
       ordersStore.fetchOrdersByClassId([classId.value]),
@@ -1300,6 +1312,9 @@ async function updateSettings() {
       isPlusReadingEnabled: isPlusReadingEnabled.value,
       mustClaimToView: mustClaimToView.value,
       tableOfContents: tableOfContents.value,
+      // Toggling the field off sets this to undefined; send '' so the listing
+      // value is cleared instead of omitted (which would keep the old value).
+      descriptionFull: descriptionFull.value ?? '',
       enableCustomMessagePage: enableCustomMessagePage.value,
     })
     await navigateTo(localeRoute({

--- a/app/pages/new-book.vue
+++ b/app/pages/new-book.vue
@@ -176,7 +176,14 @@ onMounted(() => {
     handleMintNFTSubmit({ classId: classId.value })
   }
   else if (data?.epubMetadata && data?.fileRecords) {
-    bookName.value = data?.epubMetadata?.title
+    // Resuming an in-progress upload (e.g. a refresh before ISCN registration):
+    // keep the descriptionFull draft so the ISCN step can restore it.
+    bookName.value = data.epubMetadata.title
+  }
+  else {
+    // Truly fresh start (no upload session): drop any descriptionFull left over
+    // from an abandoned book in this tab so it can't bleed into the new one.
+    clearPendingDescriptionFull()
   }
 })
 
@@ -253,6 +260,7 @@ const handleMintNFTSubmit = async (res: { classId: string, nftMintCount?: number
 const handleNewBookSubmit = async () => {
   useLogEvent('book_listing_created', { class_id: classId.value })
   clearUploadFileData()
+  clearPendingDescriptionFull()
   await navigateTo(localeRoute({ name: 'my-books' }))
 }
 </script>

--- a/app/types/book.ts
+++ b/app/types/book.ts
@@ -30,6 +30,7 @@ export interface ClassListingData {
   connectedWallets?: Record<string, number>
   mustClaimToView?: boolean
   tableOfContents?: string
+  descriptionFull?: string
   enableCustomMessagePage?: boolean
   hideDownload?: boolean
   hideAudio?: boolean

--- a/app/utils/uploadFile.ts
+++ b/app/utils/uploadFile.ts
@@ -56,3 +56,39 @@ export function clearUploadFileData() {
     console.warn('Failed to clear sessionStorage:', error)
   }
 }
+
+// descriptionFull lives in the store listing now, but the new-book wizard
+// collects it on the ISCN step; this bridge carries the value across the
+// intermediate mint step until listing creation persists it.
+export const PENDING_DESCRIPTION_FULL_KEY = 'publish_book_pending_description_full'
+
+export function setPendingDescriptionFull(value: string) {
+  try {
+    sessionStorage.setItem(PENDING_DESCRIPTION_FULL_KEY, value)
+  }
+  catch (error) {
+    // eslint-disable-next-line no-console
+    console.warn('Failed to save to sessionStorage:', error)
+  }
+}
+
+export function getPendingDescriptionFull(): string {
+  try {
+    return sessionStorage.getItem(PENDING_DESCRIPTION_FULL_KEY) || ''
+  }
+  catch (error) {
+    // eslint-disable-next-line no-console
+    console.warn('Failed to read from sessionStorage:', error)
+    return ''
+  }
+}
+
+export function clearPendingDescriptionFull() {
+  try {
+    sessionStorage.removeItem(PENDING_DESCRIPTION_FULL_KEY)
+  }
+  catch (error) {
+    // eslint-disable-next-line no-console
+    console.warn('Failed to clear sessionStorage:', error)
+  }
+}


### PR DESCRIPTION
descriptionFull becomes a listing-owned field edited via the API instead of immutable on-chain ISCN metadata, so authors can revise the long description without a wallet transaction. It is now stripped from the on-chain payload on update (like hasPart) and never written for new books.

The new-book wizard still collects it on the ISCN step and carries the value to listing creation via a sessionStorage bridge; edit surfaces hide it and it is edited from the book status page instead. Bulk upload sends it to the listing rather than on-chain.

Requires: https://github.com/likecoin/likecoin-api-public/pull/1351