### PR TITLE
🐛 Preserve full preview URL with unencoded inner query

### DIFF
--- a/app/pages/preview-book.vue
+++ b/app/pages/preview-book.vue
@@ -144,7 +144,20 @@ const route = useRoute()
 const bookstoreApiStore = useBookstoreApiStore()
 const { ARWEAVE_ENDPOINT } = useRuntimeConfig().public
 
-const inputUrl = ref((route.query.url as string) || '')
+// Read the raw query string so an unencoded inner URL (e.g. ?url=https://host/path?a=b&key=c)
+// is not truncated at the first `&`, which is how route.query.url would parse it.
+function getInitialInputUrl(): string {
+  if (import.meta.client && window.location.search) {
+    const match = window.location.search.match(/[?&]url=(.*)$/s)
+    if (match?.[1]) {
+      try { return decodeURIComponent(match[1]) }
+      catch { return match[1] }
+    }
+  }
+  return (route.query.url as string) || ''
+}
+
+const inputUrl = ref(getInitialInputUrl())
 const isLoading = ref(false)
 const isBookLoaded = ref(false)
 const errorMessage = ref('')


### PR DESCRIPTION
route.query.url is split on `&`, so a shared preview link whose inner URL carries its own unencoded query (e.g. ?url=https://host/link?id=x&key=y) lost everything after the first `&` — dropping the decryption key and breaking the preview. Read the raw window.location.search instead.