### PR TITLE
♻️ Align book edit form with the new-book flow

### DIFF
--- a/app/components/BookTableOfContentsField.vue
+++ b/app/components/BookTableOfContentsField.vue
@@ -1,0 +1,17 @@
+<template>
+  <UFormField :label="$t('form.table_of_content')">
+    <UTextarea
+      v-model="modelValue"
+      :rows="8"
+      placeholder="- Chapter 1&#10;- Chapter 2&#10;  - Section 2.1"
+    />
+  </UFormField>
+</template>
+
+<script setup lang="ts">
+// Listing-owned but reads as book metadata, so both hosts render it alongside
+// the book details rather than with the sale settings.
+const modelValue = defineModel<string>()
+
+const { t: $t } = useI18n()
+</script>

--- a/app/components/ISCNForm.vue
+++ b/app/components/ISCNForm.vue
@@ -46,8 +46,7 @@
     </UFormField>
 
     <ToggleTextarea
-      v-if="showDescriptionFull"
-      v-model="formData.descriptionFull"
+      v-model="descriptionFull"
       :label="$t('iscn_form.description_full')"
       :toggle-label="$t('iscn_form.enable_description_full')"
       :placeholder="$t('iscn_form.enter_iscn_description_full', { maxLength: MAX_DESCRIPTION_FULL_LENGTH })"
@@ -406,24 +405,24 @@ const fileRecords = ref<FileRecord[]>([])
 const uploadStatus = ref('')
 const { validateWithFeedback } = useFormValidateFeedback()
 
-// descriptionFull now lives in the store listing, not on-chain metadata. Edit
-// surfaces hide it here and edit it via listing settings instead; the new-book
-// flow keeps showing it and bridges the value to listing creation.
 // showFileFields=false hides coverUrl/fingerprints/downloadableUrls for the
 // collect-only wizard, where those URLs only exist after publish uploads.
 // guardUnsavedChanges=false disables the leave-confirmation guards for hosts
 // that persist the form some other way (the wizard's localStorage draft).
 const props = withDefaults(defineProps<{
-  showDescriptionFull?: boolean
   showFileFields?: boolean
   guardUnsavedChanges?: boolean
 }>(), {
-  showDescriptionFull: true,
   showFileFields: true,
   guardUnsavedChanges: true,
 })
 
 const formData = defineModel<ISCNFormData>({ required: true })
+
+// descriptionFull is listing-owned, so it is a separate model: keeping it out of
+// formData keeps it out of the on-chain dirty check that decides whether saving
+// costs a transaction.
+const descriptionFull = defineModel<string>('descriptionFull')
 
 // Bridge the empty stored genre to the dropdown's non-empty sentinel option.
 const genreModel = computed({
@@ -514,7 +513,7 @@ function onFormValidate(): FormError[] {
   if (!data.author.name) {
     errors.push({ name: 'author.name', message: $t('iscn_form.author_name_required') })
   }
-  if ((data.descriptionFull || '').length > MAX_DESCRIPTION_FULL_LENGTH) {
+  if ((descriptionFull.value || '').length > MAX_DESCRIPTION_FULL_LENGTH) {
     errors.push({ message: $t('validation.text_cannot_exceed', { max: MAX_DESCRIPTION_FULL_LENGTH }) })
   }
   // File-derived URLs only exist where the file fields are shown; the wizard

--- a/app/components/book-status/BookDetailsSection.vue
+++ b/app/components/book-status/BookDetailsSection.vue
@@ -76,8 +76,10 @@
       <ISCNForm
         ref="iscnFormRef"
         v-model="iscnFormData"
-        :show-description-full="false"
+        v-model:description-full="descriptionFull"
       />
+
+      <BookTableOfContentsField v-model="tableOfContents" />
 
       <h4
         class="font-bold font-mono"
@@ -90,22 +92,6 @@
         v-model:is-plus-reading-enabled="isPlusReadingEnabled"
         :is-free-book="isFreeBook"
       />
-
-      <ToggleTextarea
-        v-model="descriptionFull"
-        :label="$t('iscn_form.description_full')"
-        :toggle-label="$t('iscn_form.enable_description_full')"
-        :placeholder="$t('iscn_form.enter_iscn_description_full', { maxLength: MAX_DESCRIPTION_FULL_LENGTH })"
-        :max-length="MAX_DESCRIPTION_FULL_LENGTH"
-      />
-
-      <UFormField :label="$t('form.table_of_content')">
-        <UTextarea
-          v-model="tableOfContents"
-          :rows="8"
-          placeholder="- Chapter 1&#10;- Chapter 2&#10;  - Section 2.1"
-        />
-      </UFormField>
 
       <!-- Share sales data (moderator wallets) -->
       <UCard
@@ -171,7 +157,6 @@ import { getPortfolioURL } from '~/utils'
 import type { ClassListingData } from '~/types'
 import type { ISCNFormData, ClassMetadata } from '~/types/iscn'
 import type ISCNForm from '~/components/ISCNForm.vue'
-import { MAX_DESCRIPTION_FULL_LENGTH } from '~/constant/index'
 import { isContentFingerprintEncrypted, createEmptyISCNFormData } from '~/utils/iscn'
 
 const { t: $t } = useI18n()
@@ -250,6 +235,7 @@ const readOnlyRows = computed(() => [
   { label: $t('common.title'), value: iscnFormData.value.title },
   { label: $t('iscn_form.subtitle'), value: iscnFormData.value.alternativeHeadline },
   { label: $t('common.description'), value: iscnFormData.value.description },
+  { label: $t('iscn_form.description_full'), value: descriptionFull.value },
   { label: $t('iscn_form.author_name'), value: iscnFormData.value.author.name },
   { label: $t('form.publisher'), value: iscnFormData.value.publisher.name },
   { label: $t('form.isbn'), value: iscnFormData.value.isbn },
@@ -258,6 +244,7 @@ const readOnlyRows = computed(() => [
   { label: $t('form.genre'), value: iscnFormData.value.genre },
   { label: $t('iscn_form.license'), value: iscnFormData.value.license },
   { label: $t('form.cover_image'), value: iscnFormData.value.coverUrl, mono: true },
+  { label: $t('form.table_of_content'), value: tableOfContents.value },
   {
     label: $t('nft_book_form.is_adult_only'),
     value: isAdultOnly.value ? $t('status_page.value_yes') : $t('status_page.value_no'),
@@ -270,8 +257,6 @@ const readOnlyRows = computed(() => [
     label: $t('nft_book_form.plus_reading'),
     value: isPlusReadingEnabled.value ? $t('nft_book_form.plus_reading_join') : $t('nft_book_form.plus_reading_skip'),
   },
-  { label: $t('iscn_form.description_full'), value: descriptionFull.value },
-  { label: $t('form.table_of_content'), value: tableOfContents.value },
   {
     label: $t('form.share_sales_data'),
     value: moderatorWallets.value.map(shortenWalletAddress).join('\n'),

--- a/app/components/publish/EditionDescriptionField.vue
+++ b/app/components/publish/EditionDescriptionField.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="space-y-2">
     <UButton
-      v-if="collapsible && !isOpen"
+      v-if="!isOpen"
       variant="link"
       color="neutral"
       class="p-0"
@@ -56,16 +56,18 @@ const toolbarOptions: ToolbarNames[] = [
   'preview',
 ]
 
-const { editorId, collapsible = false } = defineProps<{
-  editorId: string
-  collapsible?: boolean
-}>()
+defineProps<{ editorId: string }>()
 
 const description = defineModel<string>({ required: true })
 
-// Start open when editing an edition that already has a description;
-// only a collapsible + empty field starts collapsed.
-const isOpen = ref(!collapsible || !!description.value)
+// An edition that already has a description starts open. The edit form hydrates
+// it after mount, so watch rather than seed: the value can arrive late.
+const isOpen = ref(false)
+watch(description, (value) => {
+  if (value) {
+    isOpen.value = true
+  }
+}, { immediate: true })
 </script>
 
 <style scoped>

--- a/app/components/publish/PricingForm.vue
+++ b/app/components/publish/PricingForm.vue
@@ -55,13 +55,6 @@
               />
             </UFormField>
 
-            <!-- Editing a saved edition keeps the description under the name. -->
-            <PublishEditionDescriptionField
-              v-if="mode === 'edit'"
-              v-model="p.description"
-              :editor-id="`pricing-${index}`"
-            />
-
             <!-- 2. Price -->
             <UFormField
               :name="`prices.${index}.price`"
@@ -119,13 +112,11 @@
               </div>
             </UFormField>
 
-            <!-- New listings: description is optional and collapsed so the
-                 rarely-used editor no longer pushes the price down the card. -->
+            <!-- Collapsed by default so the rarely-used editor does not push
+                 the price down the card. -->
             <PublishEditionDescriptionField
-              v-if="mode === 'new'"
               v-model="p.description"
               :editor-id="`pricing-${index}`"
-              collapsible
             />
 
             <!-- 3. Copies / delivery -->

--- a/app/composables/useNFTClassUpdater.ts
+++ b/app/composables/useNFTClassUpdater.ts
@@ -74,7 +74,6 @@ export function useNFTClassUpdater() {
       type: metadata['@type'] || 'Book',
       title: metadata.name || '',
       description: metadata.description || '',
-      descriptionFull: metadata.descriptionFull || '',
       alternativeHeadline: metadata.alternativeHeadline || '',
       isbn: metadata.isbn || '',
       publisher: {

--- a/app/pages/new-book.vue
+++ b/app/pages/new-book.vue
@@ -47,18 +47,12 @@
           <ISCNForm
             ref="detailsFormRef"
             v-model="iscnFormData"
+            v-model:description-full="listingDraft.descriptionFull"
             :show-file-fields="false"
             :guard-unsaved-changes="false"
           />
-          <!-- Listing-owned but reads as book metadata; collected here with
-               the rest of the book details. -->
-          <UFormField :label="$t('form.table_of_content')">
-            <UTextarea
-              v-model="listingDraft.tableOfContents"
-              :rows="8"
-              placeholder="- Chapter 1&#10;- Chapter 2&#10;  - Section 2.1"
-            />
-          </UFormField>
+
+          <BookTableOfContentsField v-model="listingDraft.tableOfContents" />
         </div>
         <div v-else-if="step === 'pricing'">
           <PublishPricingForm
@@ -547,8 +541,6 @@ async function handlePublish() {
   isPublishFailed.value = false
   hasPublishStarted.value = true
   publishError.value = ''
-  // descriptionFull is collected on the details step but listing-owned.
-  listingDraft.value.descriptionFull = iscnFormData.value.descriptionFull || ''
   persistDraft()
 
   const input: PublishBookInput = {

--- a/app/types/iscn.ts
+++ b/app/types/iscn.ts
@@ -80,11 +80,12 @@ export interface ISCNRegisterPayload {
   'isbn'?: string
 }
 
+// On-chain class metadata only; listing-owned fields (descriptionFull,
+// tableOfContents) are collected separately by each host.
 export interface ISCNFormData {
   type: string
   title: string
   description: string
-  descriptionFull?: string
   alternativeHeadline?: string
   isbn: string
   publisher: {
@@ -129,7 +130,6 @@ export interface ISCNTxPayload {
 export interface ISCNValidationData {
   title?: string
   description?: string
-  descriptionFull?: string
   author?: { name: string }
   contentFingerprints?: Array<{ url: string }>
   coverUrl?: string

--- a/app/types/publish.ts
+++ b/app/types/publish.ts
@@ -63,7 +63,8 @@ export interface PricingFormSettings {
 // tableOfContents are listing-owned (not on-chain).
 export interface PublishListingDraft extends PricingFormSettings {
   prices: PriceFormItem[]
-  descriptionFull: string
+  // Cleared to undefined when the author unticks the field.
+  descriptionFull?: string
   moderatorWallets: string[]
 }
 

--- a/app/utils/iscn.ts
+++ b/app/utils/iscn.ts
@@ -1,6 +1,6 @@
 import type { ISCNRegisterPayload, ISCNTxPayload, ISCNValidationData, ISCNFormData } from '~/types/iscn'
 import type { NFTTokenMetadata } from '~/composables/useNFTMinter'
-import { MAX_DESCRIPTION_LENGTH, MAX_DESCRIPTION_FULL_LENGTH } from '~/constant'
+import { MAX_DESCRIPTION_LENGTH } from '~/constant'
 import { getApiEndpoints } from '~/constant/api'
 
 // Per-copy token metadata; shared by the single-publish and bulk-upload
@@ -46,7 +46,6 @@ export function createEmptyISCNFormData(overrides: Partial<ISCNFormData> = {}): 
     type: 'Book',
     title: '',
     description: '',
-    descriptionFull: '',
     alternativeHeadline: '',
     isbn: '',
     publisher: { name: '', description: '' },
@@ -164,10 +163,6 @@ export function validateISCNForm(
   if (requireFileUrls
     && (!Array.isArray(data.contentFingerprints) || !data.contentFingerprints.some((f: { url: string }) => !!f.url))) {
     errors.push('Please provide at least one content URL')
-  }
-
-  if (data.descriptionFull && data.descriptionFull.length > MAX_DESCRIPTION_FULL_LENGTH) {
-    errors.push(`Full description cannot exceed ${MAX_DESCRIPTION_FULL_LENGTH} characters`)
   }
 
   if (!data.coverUrl) {


### PR DESCRIPTION
descriptionFull is listing-owned, not on-chain metadata, so it moves out of ISCNFormData into a dedicated ISCNForm model. Each host binds its own listing state, so the edit form can show the field under the description (as the wizard already does) without dirtying the on-chain snapshot that decides whether saving costs a transaction. The wizard no longer bridges the value into listingDraft at publish time.

The status page also kept table of contents under the sale settings; move it back with the book details and extract BookTableOfContentsField for both hosts.

PricingForm rendered the edition description twice — expanded above the price when editing, collapsed below it when new. Keep the collapsed one for both. Its auto-open now watches the model, since EditionEditForm hydrates the edition after mount and the field is patched in place rather than remounted.