### PR TITLE
⬆️ Bump pdfjs-dist from 5.3.31 to 6.1.200

### DIFF
--- a/app/pages/preview-book.vue
+++ b/app/pages/preview-book.vue
@@ -305,7 +305,7 @@ async function loadBook() {
   }
 
   if (pdfDocument) {
-    pdfDocument.destroy()
+    pdfDocument.loadingTask.destroy()
     pdfDocument = null
     isPdfLoaded.value = false
   }
@@ -443,7 +443,7 @@ onBeforeUnmount(() => {
     rendition = null
   }
   if (pdfDocument) {
-    pdfDocument.destroy()
+    pdfDocument.loadingTask.destroy()
     pdfDocument = null
   }
 })

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "jszip": "^3.10.1",
     "jwt-decode": "^4.0.0",
     "md-editor-v3": "^4.2.2",
-    "pdfjs-dist": "^5.3.31",
+    "pdfjs-dist": "^6.1.200",
     "pinia": "^3.0.1",
     "posthog-js": "^1.372.3",
     "uuid": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2634,77 +2634,77 @@
     multiformats "^13.0.0"
     murmurhash3js-revisited "^3.0.0"
 
-"@napi-rs/canvas-android-arm64@0.1.94":
-  version "0.1.94"
-  resolved "https://registry.yarnpkg.com/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.94.tgz#a3de34092278d17ecb4011bc74af50046ec7323b"
-  integrity sha512-YQ6K83RWNMQOtgpk1aIML97QTE3zxPmVCHTi5eA8Nss4+B9JZi5J7LHQr7B5oD7VwSfWd++xsPdUiJ1+frqsMg==
+"@napi-rs/canvas-android-arm64@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-1.0.2.tgz#8d455d06a8f282a4918bf133dd085dba9b746062"
+  integrity sha512-IMXKVQod0ol4vt3gmClUfXz4JAgHYESGPCUqmH3lQxBoL0K/2greJaQE1HVBVxWWFKfLc4OLZVdxg7kXVyXv+g==
 
-"@napi-rs/canvas-darwin-arm64@0.1.94":
-  version "0.1.94"
-  resolved "https://registry.yarnpkg.com/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.94.tgz#426199634c33e3eec1d6e25bbf00da1b2dfe7e82"
-  integrity sha512-h1yl9XjqSrYZAbBUHCVLAhwd2knM8D8xt081Pv40KqNJXfeMmBrhG1SfroRymG2ak+pl42iQlWjFZ2Z8AWFdSw==
+"@napi-rs/canvas-darwin-arm64@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-1.0.2.tgz#9f4ce7ab1f9bc105638a743274af03571bf56cff"
+  integrity sha512-Sc8tPi6cF+5lqOzCCKFALJHhDiRwyMzTPYm3bbhdXsOunU0lQO5f05ucyOzN2r55I23Hg5bsjH63uSCvWp3EgQ==
 
-"@napi-rs/canvas-darwin-x64@0.1.94":
-  version "0.1.94"
-  resolved "https://registry.yarnpkg.com/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.94.tgz#0d4f082d3c2e4e9bc9320d6c517ddd733982c4a3"
-  integrity sha512-rkr/lrafbU0IIHebst+sQJf1HjdHvTMN0GGqWvw5OfaVS0K/sVxhNHtxi8oCfaRSvRE62aJZjWTcdc2ue/o6yw==
+"@napi-rs/canvas-darwin-x64@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-1.0.2.tgz#5ff9935856fa3409cb02fa17cd853005ea1f7d88"
+  integrity sha512-niDXZ9LhKB1zLrUdYB64RHQFDGz9rr0eGx061qtJJU3U20EMMIx28ADF5fVYbhtOgkWQrBjFicfaye1yM0U62A==
 
-"@napi-rs/canvas-linux-arm-gnueabihf@0.1.94":
-  version "0.1.94"
-  resolved "https://registry.yarnpkg.com/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.94.tgz#69102567134651c7a9579c9e1fbc54385a864c0a"
-  integrity sha512-q95TDo32YkTKdi+Sp2yQ2Npm7pmfKEruNoJ3RUIw1KvQQ9EHKL3fii/iuU60tnzP0W+c8BKN7BFstNFcm2KXCQ==
+"@napi-rs/canvas-linux-arm-gnueabihf@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-1.0.2.tgz#fbee1f3a4d6a27f1be55399487c2bf342b9c3bb6"
+  integrity sha512-sgatQL9JxGRH/Amzcvu0P3t8Am3duou74CisfuJ41Dwt8cWy723z/9KZ8LlgmxfypEwEZxSTNFJtU8d281lmhQ==
 
-"@napi-rs/canvas-linux-arm64-gnu@0.1.94":
-  version "0.1.94"
-  resolved "https://registry.yarnpkg.com/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.94.tgz#e5c6420839862353d0d1ab023f5a0cb12058dc28"
-  integrity sha512-Je5/gKVybWAoIGyDOcJF1zYgBTKWkPIkfOgvCzrQcl8h7DiDvRvEY70EapA+NicGe4X3DW9VsCT34KZJnerShA==
+"@napi-rs/canvas-linux-arm64-gnu@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-1.0.2.tgz#6432cb861370437f0b1206fe45ed0cbd4ca32bf4"
+  integrity sha512-dgKuX0peF3xwY6ZF5QxGS4wbfDqpoFAJYXiLSp+guZKARQUKMkRqZSDrXKj7nfrec3UCMzC0PFCPte0ES98AiA==
 
-"@napi-rs/canvas-linux-arm64-musl@0.1.94":
-  version "0.1.94"
-  resolved "https://registry.yarnpkg.com/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.94.tgz#b73d97e5f5e9c8c6b3e8f556d436dc6e3048f864"
-  integrity sha512-9YleDDauDEZNsFnfz3HyZvp1LK1ECu8N2gDUg1wtL7uWLQv8dUbfVeFtp5HOdxht1o7LsWRmQeqeIbnD4EqE2A==
+"@napi-rs/canvas-linux-arm64-musl@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-1.0.2.tgz#65445774362b990195665ce2c14605a342c83887"
+  integrity sha512-qwROoDIC9upfvDoRLuPn2aNg9CGW1x0Ygr4k2Or+8paA9d0qBLwk87U+g8KQpoOviKoPoiwl97kvBYuYD7qZoA==
 
-"@napi-rs/canvas-linux-riscv64-gnu@0.1.94":
-  version "0.1.94"
-  resolved "https://registry.yarnpkg.com/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.94.tgz#9485f257430ca76f968fb8c5519788e75148b500"
-  integrity sha512-lQUy9Xvz7ch8+0AXq8RkioLD41iQ6EqdKFu5uV40BxkBDijB2SCm1jna/BRhqitQRSjwAk2KlLUxTjHChyfNGg==
+"@napi-rs/canvas-linux-riscv64-gnu@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-1.0.2.tgz#50b27e5bb7ffdaf8dabb3e36dcae2eb882b3d934"
+  integrity sha512-fXRjnPihdnbO6qy1QQOgxAonb68A0TCEG7rj1x7v7rxNElsE8EVIKIEUTvyDtU+sthYSbX+8e7g3oZiLGnOmxw==
 
-"@napi-rs/canvas-linux-x64-gnu@0.1.94":
-  version "0.1.94"
-  resolved "https://registry.yarnpkg.com/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.94.tgz#c4737b8ff1a3754e9554a02138c7895c9d38df85"
-  integrity sha512-0IYgyuUaugHdWxXRhDQUCMxTou8kAHHmpIBFtbmdRlciPlfK7AYQW5agvUU1PghPc5Ja3Zzp5qZfiiLu36vIWQ==
+"@napi-rs/canvas-linux-x64-gnu@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-1.0.2.tgz#80e7d573ea0301d48e5de30cd983dbd77da888d1"
+  integrity sha512-nPR97DXhbWIAy7yazF3jc06kEPMqYMLmPzFOVNlwKPfIoSChnI+x7dc0hTLaihz3jxrjL6j4BbA7earxfx4X3g==
 
-"@napi-rs/canvas-linux-x64-musl@0.1.94":
-  version "0.1.94"
-  resolved "https://registry.yarnpkg.com/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.94.tgz#618037b5f70743b23355d5d9a1c3f3f507418083"
-  integrity sha512-xuetfzzcflCIiBw2HJlOU4/+zTqhdxoe1BEcwdBsHAd/5wAQ4Pp+FGPi5g74gDvtcXQmTdEU3fLQvHc/j3wbxQ==
+"@napi-rs/canvas-linux-x64-musl@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-1.0.2.tgz#9fe3a50cec0931cd2f200d8a7bac91d8b0ddd5a0"
+  integrity sha512-l7zZY5+jL5qnBZtDz7CoBtY6p7EkHu422g/0zWwrOrzIwWyWxZFRfZZORY1UG7YApymPLx+UbOkN206xXn/c1Q==
 
-"@napi-rs/canvas-win32-arm64-msvc@0.1.94":
-  version "0.1.94"
-  resolved "https://registry.yarnpkg.com/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.94.tgz#e6c9eb5904058188fb3ea3b2483e7d923b790cbf"
-  integrity sha512-2F3p8wci4Q4vjbENlQtSibqFWxBdpzYk1c8Jh1mqqLE92rBKElG018dBJ6C8Dp49vE350Hmy5LrfdLgFKMG8sg==
+"@napi-rs/canvas-win32-arm64-msvc@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-1.0.2.tgz#d30e2841f33602ff9ebf72fc028beeee1577f7c8"
+  integrity sha512-yE0koHCFF4PIbMc2o2SEALhnipz7WBISh5glLvQiomtIoCcW0np3H4Lw93ceJAfJttTTeIIWFbwH84F7EVzjMQ==
 
-"@napi-rs/canvas-win32-x64-msvc@0.1.94":
-  version "0.1.94"
-  resolved "https://registry.yarnpkg.com/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.94.tgz#495b41fdeec9312be047c8305eb062e53532cb6a"
-  integrity sha512-hjwaIKMrQLoNiu3724octSGhDVKkBwJtMeQ3qUXOi+y60h2q6Sxq3+MM2za3V88+XQzzwn0DgG0Xo6v6gzV8kQ==
+"@napi-rs/canvas-win32-x64-msvc@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-1.0.2.tgz#861ba5e486ff1aa381f325c27ce88cf9f2370626"
+  integrity sha512-okU8/t2foV6C31n0GtvEMbfD5rOFc70+/6xUNME9Guld29sgSOIGUEDScAWFlcP3k5TYQRl9TNkwJEEjh15w8A==
 
-"@napi-rs/canvas@^0.1.88":
-  version "0.1.94"
-  resolved "https://registry.yarnpkg.com/@napi-rs/canvas/-/canvas-0.1.94.tgz#17e0bfdd9cbe3e4403335a7242e880eedf382c3f"
-  integrity sha512-8jBkvqynXNdQPNZjLJxB/Rp9PdnnMSHFBLzPmMc615nlt/O6w0ergBbkEDEOr8EbjL8nRQDpEklPx4pzD7zrbg==
+"@napi-rs/canvas@^1.0.0":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@napi-rs/canvas/-/canvas-1.0.2.tgz#62431df3a4c875006e198979beb8a873cbca0eb0"
+  integrity sha512-EYEqlMYaCbpZDz+IgDH5xp9MTd3ui4dmGqbQYryhMLnSRxrhHKq5KQWHHKxFUcEP4Hp8/BWgvqXocX4j7iSbOQ==
   optionalDependencies:
-    "@napi-rs/canvas-android-arm64" "0.1.94"
-    "@napi-rs/canvas-darwin-arm64" "0.1.94"
-    "@napi-rs/canvas-darwin-x64" "0.1.94"
-    "@napi-rs/canvas-linux-arm-gnueabihf" "0.1.94"
-    "@napi-rs/canvas-linux-arm64-gnu" "0.1.94"
-    "@napi-rs/canvas-linux-arm64-musl" "0.1.94"
-    "@napi-rs/canvas-linux-riscv64-gnu" "0.1.94"
-    "@napi-rs/canvas-linux-x64-gnu" "0.1.94"
-    "@napi-rs/canvas-linux-x64-musl" "0.1.94"
-    "@napi-rs/canvas-win32-arm64-msvc" "0.1.94"
-    "@napi-rs/canvas-win32-x64-msvc" "0.1.94"
+    "@napi-rs/canvas-android-arm64" "1.0.2"
+    "@napi-rs/canvas-darwin-arm64" "1.0.2"
+    "@napi-rs/canvas-darwin-x64" "1.0.2"
+    "@napi-rs/canvas-linux-arm-gnueabihf" "1.0.2"
+    "@napi-rs/canvas-linux-arm64-gnu" "1.0.2"
+    "@napi-rs/canvas-linux-arm64-musl" "1.0.2"
+    "@napi-rs/canvas-linux-riscv64-gnu" "1.0.2"
+    "@napi-rs/canvas-linux-x64-gnu" "1.0.2"
+    "@napi-rs/canvas-linux-x64-musl" "1.0.2"
+    "@napi-rs/canvas-win32-arm64-msvc" "1.0.2"
+    "@napi-rs/canvas-win32-x64-msvc" "1.0.2"
 
 "@napi-rs/wasm-runtime@^0.2.11":
   version "0.2.12"
@@ -11274,11 +11274,6 @@ node-mock-http@^1.0.4:
   resolved "https://registry.yarnpkg.com/node-mock-http/-/node-mock-http-1.0.4.tgz#21f2ab4ce2fe4fbe8a660d7c5195a1db85e042a4"
   integrity sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==
 
-node-readable-to-web-readable-stream@^0.4.2:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/node-readable-to-web-readable-stream/-/node-readable-to-web-readable-stream-0.4.2.tgz#634da58d3fe42a47d4608f1d7f14f85e18daeabe"
-  integrity sha512-/cMZNI34v//jUTrI+UIo4ieHAB5EZRY/+7OmXZgBxaWBMcW2tGdceIw06RFxWxrKZ5Jp3sI2i5TsRo+CBhtVLQ==
-
 node-releases@^2.0.36:
   version "2.0.44"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.44.tgz#212c9b983f5bb70d311dd68c27d55dd0e65d1ca7"
@@ -11932,13 +11927,12 @@ pathe@^2.0.1, pathe@^2.0.3:
   resolved "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz"
   integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
 
-pdfjs-dist@^5.3.31:
-  version "5.4.624"
-  resolved "https://registry.yarnpkg.com/pdfjs-dist/-/pdfjs-dist-5.4.624.tgz#f00911beb481de998c29e8e464b88d500cb1f4a8"
-  integrity sha512-sm6TxKTtWv1Oh6n3C6J6a8odejb5uO4A4zo/2dgkHuC0iu8ZMAXOezEODkVaoVp8nX1Xzr+0WxFJJmUr45hQzg==
+pdfjs-dist@^6.1.200:
+  version "6.1.200"
+  resolved "https://registry.yarnpkg.com/pdfjs-dist/-/pdfjs-dist-6.1.200.tgz#4d957377ab57e397172fccb96bfe008dbcb2ddd6"
+  integrity sha512-o8MolyzirkkLrcdsae/HEOiIcXWI7DS5zGpvqW8xTC2YUsW30rltFw2bDGvw/fskUdEMrQm2br68jzDS5BH2vw==
   optionalDependencies:
-    "@napi-rs/canvas" "^0.1.88"
-    node-readable-to-web-readable-stream "^0.4.2"
+    "@napi-rs/canvas" "^1.0.0"
 
 perfect-debounce@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
pdf.js v6 removes PDFDocumentProxy.destroy(), which the PDF preview called on reset and on unmount, so both sites would have thrown a TypeError at runtime. Call destroy() on the loading task instead, reached through the new loadingTask getter on the document proxy.