### PR TITLE
🐛 Fix sales report book names for legacy and backfilled records

### DIFF
--- a/app/components/SalesReportCommissionHistory.vue
+++ b/app/components/SalesReportCommissionHistory.vue
@@ -62,12 +62,18 @@
       >
         <template #classId-cell="{ row }">
           <a
-            :href="`${BOOK3_URL}/store/${row.original.classId || ''}`"
+            v-if="row.original.classId"
+            :href="`${BOOK3_URL}/store/${row.original.classId}`"
             target="_blank"
             rel="noopener noreferrer"
           >
-            {{ (row.original.classId ? nftStore.getClassMetadataById(row.original.classId)?.name : '') || row.original.classId || '' }}
+            {{ nftStore.getClassNameById(row.original.classId) || row.original.classId }}
           </a>
+          <span v-else-if="row.original.description">{{ row.original.description }}</span>
+          <span
+            v-else
+            class="text-gray-400"
+          >-</span>
         </template>
         <template #buyerEmail-cell="{ row }">
           <a
@@ -236,7 +242,7 @@ async function loadCommissionHistory() {
     const classIds = new Set<string>(commissionHistory.value
       .filter((row: CommissionRow) => !!row.classId)
       .map((row: CommissionRow) => row.classId as string))
-    classIds.forEach((classId: string) => nftStore.lazyFetchClassMetadataById(classId))
+    classIds.forEach((classId: string) => nftStore.lazyFetchClassNameById(classId))
   }
   catch (e) {
     console.error(e)
@@ -293,7 +299,7 @@ async function exportCommissionHistory() {
       }
       return type
     })(),
-    bookName: (row.classId ? nftStore.getClassMetadataById(row.classId)?.name : '') || '',
+    bookName: (row.classId ? nftStore.getClassNameById(row.classId) : row.description) || '',
     classId: row.classId || '',
     buyerEmail: row.buyerEmail || '',
     amount: convertDecimalToAmount(row.amount, row.currency),

--- a/app/components/SalesReportPlusReading.vue
+++ b/app/components/SalesReportPlusReading.vue
@@ -68,12 +68,17 @@
       >
         <template #classId-cell="{ row }">
           <a
-            :href="`${BOOK3_URL}/store/${row.original.classId || ''}`"
+            v-if="row.original.classId"
+            :href="`${BOOK3_URL}/store/${row.original.classId}`"
             target="_blank"
             rel="noopener noreferrer"
           >
-            {{ (row.original.classId ? nftStore.getClassMetadataById(row.original.classId)?.name : '') || row.original.classId || '' }}
+            {{ nftStore.getClassNameById(row.original.classId) || row.original.classId }}
           </a>
+          <span
+            v-else
+            class="text-gray-400"
+          >-</span>
         </template>
         <template #status-cell="{ row }">
           <UBadge
@@ -142,7 +147,7 @@ async function loadReport() {
     const classIds = new Set<string>(payouts.value
       .filter((row: PlusReadingReportEntry) => !!row.classId)
       .map((row: PlusReadingReportEntry) => row.classId))
-    classIds.forEach((classId: string) => nftStore.lazyFetchClassMetadataById(classId))
+    classIds.forEach((classId: string) => nftStore.lazyFetchClassNameById(classId))
   }
   catch (e) {
     error.value = (e as Error).toString()
@@ -172,7 +177,7 @@ async function exportReport() {
 
   const data = payouts.value.map((row: PlusReadingReportEntry) => ({
     periodId: row.periodId,
-    bookName: (row.classId ? nftStore.getClassMetadataById(row.classId)?.name : '') || '',
+    bookName: nftStore.getClassNameById(row.classId) || '',
     classId: row.classId,
     readingMinutes: convertMsToMinutes(row.readingTimeMs),
     listeningMinutes: convertMsToMinutes(row.ttsTimeMs),

--- a/app/stores/nft.ts
+++ b/app/stores/nft.ts
@@ -1,4 +1,5 @@
 import type { ClassMetadata } from '~/types/iscn'
+import type { ProductData } from '~/types'
 
 export const useNftStore = defineStore('nft', () => {
   const { LIKE_CO_API } = useRuntimeConfig().public
@@ -8,6 +9,13 @@ export const useNftStore = defineStore('nft', () => {
   const getClassMetadataById = computed(() => (classId: string) => classMetadataByIdMap.value[classId])
 
   const getClassListingInfoById = computed(() => (classId: string) => classListingInfoByIdMap.value[classId])
+
+  const getClassNameById = computed(() => (classId: string) => {
+    const metadataName = classMetadataByIdMap.value[classId]?.name
+    if (metadataName) { return metadataName }
+    const listingName = classListingInfoByIdMap.value[classId]?.name as ProductData['name']
+    return (typeof listingName === 'object' ? (listingName?.zh || listingName?.en) : listingName) || undefined
+  })
 
   async function fetchClassMetadataById(classId: string) {
     const { getClassMetadata } = useNFTContractReader()
@@ -33,13 +41,37 @@ export const useNftStore = defineStore('nft', () => {
     return fetchClassListingInfoById(classId)
   }
 
+  // Falls back to bookstore listing info for classes without an on-chain
+  // contract (e.g. legacy classes migrated from another chain).
+  // Never rejects, so callers can safely fire-and-forget.
+  async function lazyFetchClassNameById(classId: string) {
+    const cached = getClassNameById.value(classId)
+    if (cached) { return cached }
+    try {
+      const metadata = await lazyFetchClassMetadataById(classId)
+      if (metadata?.name) { return metadata.name }
+    }
+    catch {
+      // fallback to listing info below
+    }
+    try {
+      await lazyFetchClassListingInfoById(classId)
+    }
+    catch {
+      // no name available; callers fall back to showing the classId
+    }
+    return getClassNameById.value(classId)
+  }
+
   return {
     classMetadataByIdMap,
     getClassMetadataById,
     getClassListingInfoById,
+    getClassNameById,
     fetchClassMetadataById,
     lazyFetchClassMetadataById,
     fetchClassListingInfoById,
     lazyFetchClassListingInfoById,
+    lazyFetchClassNameById,
   }
 })

--- a/app/types/payout.ts
+++ b/app/types/payout.ts
@@ -1,6 +1,8 @@
 export interface CommissionRow {
   type: string
   classId?: string
+  // Backfilled commission docs may have no classId, only a description.
+  description?: string
   amount: number
   amountTotal: number
   currency: string


### PR DESCRIPTION
Classes migrated from another chain have no on-chain contract, so contractURI() fails and rows showed the raw class ID. Resolve names via bookstore listing info as fallback, cache the result to avoid retrying doomed RPC reads, and render backfilled commission rows without classId as description text or a dash instead of an empty link.