### PR TITLE
🚸 Scroll to UI revealed by a click in the publish flow

### DIFF
--- a/app/components/publish/PricingForm.vue
+++ b/app/components/publish/PricingForm.vue
@@ -7,7 +7,10 @@
     class="flex flex-col gap-[24px]"
     @submit.prevent
   >
-    <ul class="flex flex-col gap-[12px]">
+    <ul
+      ref="editionListRef"
+      class="flex flex-col gap-[12px]"
+    >
       <UCard
         :ui="{
           root: 'overflow-visible border-none border-transparent!',
@@ -17,6 +20,8 @@
         <li
           v-for="(p, index) in prices"
           :key="p.index"
+          data-edition-item
+          tabindex="-1"
         >
           <UCard
             :ui="{
@@ -431,6 +436,7 @@ const prices = defineModel<PriceFormItem[]>('prices', { required: true })
 const settings = defineModel<PricingFormSettings>('settings', { required: true })
 const signatureImage = defineModel<File | null>('signatureImage', { default: null })
 
+const editionListRef = ref<HTMLElement | null>(null)
 const signatureImagePreview = useObjectUrl(signatureImage)
 const shouldShowAdvanceSettings = ref(true)
 const maxSupply = ref(Number(DEFAULT_MAX_SUPPLY))
@@ -516,8 +522,14 @@ onMounted(async () => {
   }
 })
 
-function addMorePrice() {
+async function addMorePrice() {
   prices.value.push(createDefaultPriceFormItem({ index: uuidv4(), name: '增訂版' }))
+  // The new card renders above the button that was just clicked, so it lands
+  // off screen.
+  await revealElement(() => {
+    const items = editionListRef.value?.querySelectorAll<HTMLElement>('[data-edition-item]')
+    return items?.[items.length - 1]
+  })
 }
 
 function deletePrice(index: number) {

--- a/app/composables/useFormValidateFeedback.ts
+++ b/app/composables/useFormValidateFeedback.ts
@@ -18,9 +18,10 @@ export function useFormValidateFeedback() {
     if (errors.length) {
       showErrorToast([...new Set(errors.map(e => e.message))].join('\n'))
     }
-    await nextTick()
-    form.$el?.querySelector('[aria-invalid="true"]')
-      ?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    await revealElement(
+      () => form.$el?.querySelector<HTMLElement>('[aria-invalid="true"]'),
+      { block: 'center', focus: false },
+    )
     return false
   }
 

--- a/app/pages/new-book.vue
+++ b/app/pages/new-book.vue
@@ -77,7 +77,11 @@
             :cover-image-src="coverImageSrc"
             @edit="goToStep"
           />
-          <UCard v-if="isPublishing || hasPublishStarted">
+          <UCard
+            v-if="isPublishing || hasPublishStarted"
+            ref="publishProgressRef"
+            tabindex="-1"
+          >
             <template #header>
               <div class="flex justify-between items-center">
                 <h3
@@ -203,6 +207,7 @@ const uploadFormRef = ref()
 const detailsFormRef = ref()
 const pricingFormRef = ref()
 const stepTopRef = ref<HTMLElement | null>(null)
+const publishProgressRef = ref()
 
 // Collected draft state; persisted to localStorage so an accidental tab close
 // or browser quit keeps everything except the raw file blobs.
@@ -546,6 +551,9 @@ async function handlePublish() {
   hasPublishStarted.value = true
   publishError.value = ''
   persistDraft()
+  // The checklist is appended below a long review summary, so it lands off
+  // screen; without this the Publish click looks like it did nothing.
+  await revealElement(publishProgressRef)
 
   const input: PublishBookInput = {
     fileRecords: fileRecords.value.map(record => ({
@@ -610,6 +618,9 @@ async function handlePublish() {
   }
   else {
     isPublishFailed.value = true
+    // Bring the failure back into view for an author who scrolled away while
+    // the publish was running.
+    await revealElement(publishProgressRef)
   }
 }
 </script>

--- a/app/utils/scroll.ts
+++ b/app/utils/scroll.ts
@@ -1,0 +1,21 @@
+import { unrefElement } from '@vueuse/core'
+import type { MaybeComputedElementRef } from '@vueuse/core'
+
+// The app scrolls inside the layout's overflow container, not the window, and
+// scroll anchoring pins the clicked button in place, so content inserted above
+// the fold stays invisible and the click reads as a no-op. Takes a ref or
+// getter because the target usually renders only on the next tick.
+export async function revealElement(
+  target: MaybeComputedElementRef,
+  { block = 'start', focus = true }: { block?: ScrollLogicalPosition, focus?: boolean } = {},
+) {
+  if (import.meta.server) { return }
+  await nextTick()
+  const el = unrefElement(target)
+  if (!(el instanceof HTMLElement)) { return }
+  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  el.scrollIntoView({ behavior: prefersReducedMotion ? 'auto' : 'smooth', block })
+  // Focusing the container (needs tabindex="-1") rather than the first field
+  // inside keeps mobile from opening the keyboard mid-scroll.
+  if (focus) { el.focus({ preventScroll: true }) }
+}


### PR DESCRIPTION
Clicking Publish or Add edition inserts a card above the current scroll position, where scroll anchoring keeps the viewport pinned — so the click reads as a no-op. Add revealElement() to scroll the new node into view and focus it, and fold the existing scroll-to-invalid-field copy into it.