### PR TITLE
✨ Restore publish funnel analytics and instrument recent features

### DIFF
--- a/app/components/ISCNForm.vue
+++ b/app/components/ISCNForm.vue
@@ -539,20 +539,31 @@ async function handleSuggestMetadata() {
     if (mergedTags.length > existingTags.length) { hasSuggested.value = true }
 
     // Guards against cross-repo drift of the duplicated category list.
-    if (!BOOK_CATEGORIES.some(cat => cat.value === result.genre)) { return }
-    if (!formData.value.genre) {
+    const isGenreValid = BOOK_CATEGORIES.some(cat => cat.value === result.genre)
+    // Logged before the early return below so a rejected genre still counts as
+    // a suggestion; an empty genre with keywords is a partial success, not none.
+    const isGenreAutoApplied = isGenreValid && !formData.value.genre
+    useLogEvent('book_metadata_suggest_success', {
+      keywords_added: mergedTags.length - existingTags.length,
+      suggested_genre: isGenreValid ? result.genre : '',
+      is_genre_auto_applied: isGenreAutoApplied,
+    })
+    if (!isGenreValid) { return }
+    if (isGenreAutoApplied) {
       formData.value.genre = result.genre
     }
     else {
       suggestedGenre.value = result.genre
     }
   }
-  catch {
+  catch (error) {
+    useLogEvent('book_metadata_suggest_failed', { error: (error as Error)?.message })
     showErrorToast($t('iscn_form.ai_suggest_failed'))
   }
 }
 
 function applySuggestedGenre() {
+  useLogEvent('book_metadata_suggest_genre_applied', { genre: suggestedGenre.value })
   formData.value.genre = suggestedGenre.value
 }
 

--- a/app/components/publish/PricingForm.vue
+++ b/app/components/publish/PricingForm.vue
@@ -480,6 +480,16 @@ const previewCut = computed(() => {
   }
 })
 
+// A refusal is an authoring problem the author can see but we could not count.
+// Keyed on the reason itself because the readout recomputes on every tick of
+// the percentage slider, and an unguarded watcher would emit a burst per drag.
+watch(
+  () => (previewCut.value && !previewCut.value.ok ? previewCut.value.reason : ''),
+  (reason) => {
+    if (reason) { useLogEvent('book_preview_unavailable', { reason }) }
+  },
+)
+
 // UForm routes each returned error to the UFormField whose name matches
 // (prices.{i}.{field}); no per-field :error piping needed.
 const formRef = ref()

--- a/app/composables/useLogEvent.ts
+++ b/app/composables/useLogEvent.ts
@@ -19,6 +19,7 @@ export const INTERCOM_TRACKED_EVENTS: ReadonlySet<string> = new Set([
   'iscn_registration_success',
   'nft_mint_success',
   'book_listing_created',
+  'book_publish_failed',
   'iscn_metadata_updated',
   // Book management
   'my_books_view_detail',

--- a/app/composables/usePublishBook.ts
+++ b/app/composables/usePublishBook.ts
@@ -202,6 +202,10 @@ export function usePublishBook() {
           const result = await createNFTClass({ iscnFormData: iscnFormDataRef })
           classId = result.classId
         }
+        // The publish funnel milestones live here rather than in the page:
+        // only new-book.vue calls publishBook, and mint confirmation is not
+        // observable from outside (onProgress fires on broadcast, not receipt).
+        useLogEvent('iscn_registration_success', { class_id: classId, is_recovered: classExistedBeforeRun })
         onProgress?.({ classId })
       }
       else {
@@ -226,6 +230,7 @@ export function usePublishBook() {
             onProgress?.({ mintTxHash: hash })
           },
         })
+        useLogEvent('nft_mint_success', { class_id: classId, mint_count: NFT_DEFAULT_MINT_AMOUNT })
       }
 
       // Step 4: Create book listing

--- a/app/pages/new-book.vue
+++ b/app/pages/new-book.vue
@@ -322,6 +322,10 @@ async function initFromLegacyQuery(legacyClassId: string, isMintDone: boolean) {
 function resumeDraft() {
   const session = pendingSession.value
   if (session) {
+    useLogEvent('book_publish_draft_resumed', {
+      status: session.status,
+      wizard_step: session.wizardStep,
+    })
     fileRecords.value = session.fileRecords.map(record => ({ ...record }))
     epubMetadata.value = session.epubMetadata
     encryptEbook.value = session.encryptEbook
@@ -348,6 +352,7 @@ function resumeDraft() {
 }
 
 function discardDraft() {
+  useLogEvent('book_publish_draft_discarded', { status: pendingSession.value?.status })
   clearPublishSession()
   pendingSession.value = null
   showResumePrompt.value = false
@@ -508,6 +513,8 @@ function handleFilesCollected(payload: {
   useLogEvent('book_publish_upload_completed', {
     file_count: payload.fileRecords.length,
     has_epub_metadata: !!payload.epubMetadata,
+    is_encrypted: payload.isEncrypt,
+    is_sponsored: payload.isSponsored,
   })
   seedDetailsFromMetadata()
   advanceStep()
@@ -616,7 +623,13 @@ async function handlePublish() {
   if (result) {
     lastStepStatus.value = BookUploadStatus.COMPLETED
     clearPublishSession()
-    useLogEvent('book_listing_created', { class_id: result.classId })
+    useLogEvent('book_listing_created', {
+      class_id: result.classId,
+      is_encrypted: encryptEbook.value,
+      is_sponsored: sponsored.value,
+      is_preview_enabled: listingDraft.value.isPreviewEnabled,
+      preview_percentage: listingDraft.value.previewPercentage,
+    })
     await navigateTo(localeRoute({
       name: 'my-books-status-classId',
       params: { classId: result.classId },
@@ -624,6 +637,13 @@ async function handlePublish() {
   }
   else {
     isPublishFailed.value = true
+    // lastStepStatus holds the step that was in flight: onStatusChange above
+    // filters FAILED out, so it is never overwritten by the failure itself.
+    useLogEvent('book_publish_failed', {
+      step: lastStepStatus.value,
+      error: publishError.value,
+      class_id: classId.value || undefined,
+    })
     // Bring the failure back into view for an author who scrolled away while
     // the publish was running.
     await revealElement(publishProgressRef)

--- a/test/analytics-events.test.mjs
+++ b/test/analytics-events.test.mjs
@@ -1,0 +1,45 @@
+// Lives outside app/ so Nuxt never auto-imports it into the bundle.
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// Intercom silently drops event names past its 120-per-workspace cap, so the
+// allowlist is a scarce resource — an entry with no emitter wastes a slot and
+// leaves a funnel step looking dead. Nothing links the Set to the call sites
+// (useLogEvent takes a plain string), so assert the link here instead: the
+// new-book rebuild dropped both blockchain milestones this way and the stale
+// allowlist entries hid it for three weeks.
+const APP_DIR = path.join(fileURLToPath(import.meta.url), '../../app')
+const SOURCE_FILE = path.join(APP_DIR, 'composables/useLogEvent.ts')
+
+const source = fs.readFileSync(SOURCE_FILE, 'utf8')
+
+const setBody = source.match(/INTERCOM_TRACKED_EVENTS[^=]*=\s*new Set\(\[([\s\S]*?)\]\)/)?.[1]
+const allowlist = [...(setBody ?? '').matchAll(/'([^']+)'/g)].map(m => m[1])
+
+// Every other file under app/, concatenated — a name may be logged directly or
+// passed through a variable (settings/index.vue, usePurchaseLinkActions.ts), so
+// match the literal anywhere rather than only inside a useLogEvent() call.
+const emitterSources = fs.readdirSync(APP_DIR, { recursive: true })
+  .map(entry => path.join(APP_DIR, entry.toString()))
+  .filter(file => /\.(ts|vue)$/.test(file) && file !== SOURCE_FILE)
+  .map(file => fs.readFileSync(file, 'utf8'))
+  .join('\n')
+
+test('the allowlist parses', () => {
+  // Without this a broken regex would make every assertion below vacuous.
+  assert.ok(setBody, 'could not find the INTERCOM_TRACKED_EVENTS Set literal')
+  assert.ok(allowlist.length > 0, 'parsed no event names out of the allowlist')
+})
+
+test('every allowlisted event has an emitter', async (t) => {
+  await Promise.all(allowlist.map(name => t.test(name, () => {
+    assert.ok(
+      emitterSources.includes(`'${name}'`),
+      `'${name}' is allowlisted for Intercom but nothing under app/ logs it — `
+      + 'wire up the emitter or drop it from INTERCOM_TRACKED_EVENTS.',
+    )
+  })))
+})


### PR DESCRIPTION
The new-book wizard rebuild (f8084d54c) dropped the only call sites for iscn_registration_success and nft_mint_success but left their entries in INTERCOM_TRACKED_EVENTS, so since early July the funnel has shown uploads going straight to listings — both blockchain steps, and every publish that died between them, invisible. Restore both from usePublishBook, where mint confirmation is actually observable (onProgress fires on broadcast, not receipt), and add book_publish_failed so the drop-off has a denominator.

Recent features shipped with intent but no outcome: AI suggest logged the click and never the result, and the DRM-to-GCS and free-preview paths were indistinguishable in every chart. Add success, failure and genre-applied events for the suggestion, draft resume/discard events, a preview-refusal event, and segment the existing upload and listing events by is_encrypted, is_sponsored and the preview settings.

Guard the allowlist with a node --test check that every name in INTERCOM_TRACKED_EVENTS has an emitter under app/, so a call site cannot disappear silently again.